### PR TITLE
[#1927] Increased lock timeout for ech use of yum

### DIFF
--- a/ansible-scylla-loader/tasks/RedHat.yml
+++ b/ansible-scylla-loader/tasks/RedHat.yml
@@ -9,6 +9,7 @@
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
+    lock_timeout: 60
   become: true
 
 - name: Install ELRepo kernel
@@ -28,6 +29,7 @@
       yum:
         name: kernel-ml
         state: present
+        lock_timeout: 60
   when: elrepo_kernel == True and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
   become: true
 
@@ -92,5 +94,6 @@
   yum:
     name: tlp-stress
     state: latest
+    lock_timeout: 60
   become: true
 

--- a/ansible-scylla-manager/tasks/RedHat.yml
+++ b/ansible-scylla-manager/tasks/RedHat.yml
@@ -9,6 +9,7 @@
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
+    lock_timeout: 60
   become: true
 
 - name: add scylla-manager repo
@@ -26,6 +27,7 @@
           - scylla-manager-server
           - scylla-manager-client
         state: present
+        lock_timeout: 60
       become: true
       when: enable_upgrade is not defined or enable_upgrade is defined and enable_upgrade|bool == False
 
@@ -34,6 +36,7 @@
           - scylla-manager-server
           - scylla-manager-client
         state: latest
+        lock_timeout: 60
       become: true
       when: enable_upgrade is defined and enable_upgrade|bool
 

--- a/ansible-scylla-manager/tasks/add-clusters.yml
+++ b/ansible-scylla-manager/tasks/add-clusters.yml
@@ -22,7 +22,3 @@
       --password {{ item.password }} \
       {% endif %}
   when: cluster_already_added is not defined or cluster_already_added.stdout != "present"
-
-
-
-

--- a/ansible-scylla-monitoring/tasks/RedHat.yml
+++ b/ansible-scylla-monitoring/tasks/RedHat.yml
@@ -12,6 +12,7 @@
       name:
         - "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
       state: present
+      lock_timeout: 60
 
   - name: install additional dependencies
     yum:
@@ -19,6 +20,7 @@
         - git
         - python3
       state: present
+      lock_timeout: 60
   become: true
 
 - name: install prerequisite python-yaml
@@ -42,6 +44,7 @@
           - podman
           - podman-docker
         state: absent
+        lock_timeout: 60
 
     - name: download docker-ce repo
       get_url:
@@ -57,6 +60,7 @@
           - docker-ce-cli
           - containerd.io
         state: present
+        lock_timeout: 60
 
     - name: create docker group
       group:

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -10,6 +10,7 @@
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
+    lock_timeout: 60
   when: install_type == 'online' and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
   become: true
 
@@ -30,6 +31,7 @@
       yum:
         name: kernel-ml
         state: present
+        lock_timeout: 60
   when: elrepo_kernel == True and install_type == 'online' and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
   become: true
 
@@ -55,6 +57,7 @@
     yum:
       name: scylla
       state: latest
+      lock_timeout: 60
     when: scylla_version == 'latest' and scylla_edition == 'oss'
 
   - name: Install latest Enterprise Scylla
@@ -67,12 +70,14 @@
     yum:
       name: "scylla-{{ scylla_version }}"
       state: present
+      lock_timeout: 60
     when: scylla_version != 'latest' and scylla_edition == 'oss'
 
   - name: Install specified Enterprise Scylla
     yum:
       name: "scylla-enterprise-{{ scylla_version }}"
       state: present
+      lock_timeout: 60
     when: scylla_version != 'latest' and scylla_edition == 'enterprise'
   become: true
 
@@ -100,12 +105,14 @@
       yum:
         name: scylla-manager-agent
         state: present
+        lock_timeout: 60
       when: scylla_manager_agent_upgrade is not defined or scylla_manager_agent_upgrade|bool == False
 
     - name: install the latest manager agent
       yum:
         name: scylla-manager-agent
         state: latest
+        lock_timeout: 60
       when: scylla_manager_agent_upgrade is defined and scylla_manager_agent_upgrade|bool
 
   become: true


### PR DESCRIPTION
Fixes #16 

Doubles the lock timeout to avoid failing build steps when yum doesn't release it's lock within 30 seconds.