### PR TITLE
Support ubuntu 20.04 (focal)

### DIFF
--- a/ansible-scylla-manager/meta/main.yml
+++ b/ansible-scylla-manager/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
       - 7
   - name: Ubuntu
     versions:
+      - 20.04
       - 18.04
       - 16.04
   galaxy_tags: 

--- a/ansible-scylla-node/meta/main.yml
+++ b/ansible-scylla-node/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
     - 9
   - name: Ubuntu
     versions:
+    - 20.04
     - 16.04
     - 18.04
   - galaxy_tags:


### PR DESCRIPTION
Scylla server successfully starts on ubuntu focal after adding both this and the following PR:
https://github.com/scylladb/scylla-ansible-roles/pull/35

Not tested on production yet, nor have I attempted to install scylla manager.