### PR TITLE
Remove perftune covered by scylla_sysconfig_setup

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -139,54 +139,6 @@
       scylla_sysconfig_setup --setup-nic-and-disks --nic {{ scylla_nic }}
   become: true
 
-- name: perftune related operations
-  block:
-  #TODO: additional testing on Debian/Ubuntu required.
-  - name: set perf_mode for 4 cores or less
-    set_fact:
-      perf_mode: mq
-    when: ansible_processor_vcpus <= 4
-
-  - name: set perf_mode for 5 to 8 cores
-    set_fact:
-      perf_mode: "sq"
-    when: ansible_processor_vcpus > 4 and ansible_processor_vcpus <= 8
-
-  - name: set perf_mode for 9+ cores
-    set_fact:
-      perf_mode: "sq_split"
-    when: ansible_processor_vcpus > 8
-
-  - name: find perftune in the system
-    shell: |
-      if [ -f /usr/lib/scylla/perftune.py ]; then echo non-reloc; fi
-      if [ -f /opt/scylladb/scripts/perftune.py ]; then echo reloc; fi
-    register: is_reloc
-
-  - name: set perftune command for reloc
-    set_fact:
-      perftune: "PATH=$PATH:/opt/scylladb/bin /opt/scylladb/scripts/perftune.py --tune net --get-cpu-mask --nic {{ scylla_nic }} --mode {{ perf_mode }} | /opt/scylladb/scripts/hex2list.py"
-    when: is_reloc.stdout == 'reloc'
-
-  - name: set perftune command for non-reloc
-    set_fact:
-      perftune: "/usr/lib/scylla/perftune.py --tune net --get-cpu-mask --nic {{ scylla_nic }} --mode {{ perf_mode }} | /usr/lib/scylla/hex2list.py"
-    when: is_reloc.stdout == 'non-reloc'
-
-  - name: set cpuset command
-    set_fact:
-      cpuset: "scylla_cpuset_setup --cpuset `{{ perftune }}`"
-
-  - name: run cpuset
-    shell: |
-      {{ cpuset }}
-    become: true
-
-  - name: run perftune
-    shell: |
-      {{ perftune }}
-    become: true
-
 - name: configure custom scylla.yaml paramaters
   lineinfile:
     path: /etc/scylla/scylla.yaml


### PR DESCRIPTION
This block of code no longer works because the `hex2list.py` script no longer exists, as of 4.3.
https://github.com/scylladb/scylla/commit/85f76e80b43d8cfde4739a2a53c44c6e8850d793#diff-917434377d874a258a5aa772c8ec3b17ea3c966980e79f5fe70f387ee99dfdc1

I'm a bit unclear what was the motivation for adding this code block - perhaps scylla_cpuset_setup is or was unoptimal in the manner that it selected `perf_mode`?
https://github.com/scylladb/scylla-ansible-roles/issues/2

Without this block this seems to give a reasonable result for an Ec2 `i3.large` instance without the tuning:
```
cat /etc/scylla.d/cpuset.conf
# DO NO EDIT
# This file should be automatically configure by scylla_cpuset_setup
#
# CPUSET="--cpuset 0 --smp 1"
CPUSET="--cpuset 0-1 "
```