### PR TITLE
Fix Debian installation

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -119,7 +119,7 @@ scylla_yaml_params:
 # The playbook will use the CA certificate to generate a signed host certificate for the .pem file and push them into the nodes
 # To skip this configuration entirely, set enabled: false for both options or comment out the scylla_ssl variable.
 scylla_ssl:
-  cert_path: /etc/scylla/
+  cert_path: /etc/scylla
   internode:
     enabled: true
     internode_encryption: all

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -66,13 +66,13 @@
 
   - name: Install specified OSS Scylla
     apt:
-      name: "scylla-{{ scylla_version }}"
+      name: "scylla={{ scylla_version }}*"
       state: present
     when: scylla_version != 'latest' and scylla_edition == 'oss'
 
   - name: Install specified Enterprise Scylla
     apt:
-      name: "scylla-enterprise-{{ scylla_version }}"
+      name: "scylla-enterprise={{ scylla_version }}*"
       state: present
     when: scylla_version != 'latest' and scylla_edition == 'enterprise'
   become: true

--- a/ansible-scylla-node/tasks/ssl.yml
+++ b/ansible-scylla-node/tasks/ssl.yml
@@ -14,7 +14,7 @@
       openssl_csr:
         path: "./ssl/ca/{{ scylla_cluster_name }}-ca.csr"
         privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
-        common_name: "{{ scylla_cluster_name}}.internal"
+        common_name: "{{ scylla_cluster_name }}.internal"
 
     - name: Generate a Self Signed OpenSSL certificate for the CA
       openssl_certificate:


### PR DESCRIPTION
This PR fixes ansible-scylla-node to work on Debian hosts. Three things were fixed:
* correct `cert_path`
* Scylla installation
* removed not working perftune tasks