### PR TITLE
Set correct values in io.conf

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -86,7 +86,7 @@ scylla_io_probe: True
 #       write_iops: 9722999
 #       write_bandwidth: 352182944
 
-io_conf: 'SEASTAR_IO="--io-properties-file /etc/scylla.d/io_properties.yaml"'
+io_conf: 'SEASTAR_IO="--io-properties-file=/etc/scylla.d/io_properties.yaml"'
 
 # Seeds node list
 scylla_seeds:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -34,13 +34,6 @@
     - set_fact:
         io_properties: "{{ _io_properties.stdout }}"
 
-    - name: store /etc/scylla.d/io.conf
-      shell: |
-        cat /etc/scylla.d/io.conf
-      register: _io_conf
-
-    - set_fact:
-        io_conf: "{{ _io_conf.stdout_lines[0] }}"
   when: scylla_io_probe|bool == True
   run_once: true
   become: true


### PR DESCRIPTION
Without this change my io.conf file was empty after running example playbook. This way we ensure that `io_conf` value from `defaults/main.yml` will be used instead.