### PR TITLE
Async extra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+__pycache__

--- a/example-playbooks/async_extra/README.md
+++ b/example-playbooks/async_extra/README.md
@@ -112,6 +112,7 @@ Features:
 - always outputs started and finished fields
 - default `cleanup` mode cleanups only an alias if the job was specified
   by its name. if it was specified by a jid it deletes the whole state.
+- `full_cleanup` deletes job's state and all related links
 
 Quick start
 ---

--- a/example-playbooks/async_extra/README.md
+++ b/example-playbooks/async_extra/README.md
@@ -5,6 +5,22 @@ The set of modules and plugins offers the mechanism to organize
 named jobs on top of the Ansible standard async architecture. It
 is fully compatible with Ansible native async wrapper and status.
 
+Quick start
+===
+
+    $ ansible-playbook ./play.yml
+
+    ---
+    - name: Async recoverable job blah
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 10
+        alias: blah
+        async: 1000
+        retries: 100
+        delay: 5
+
 Architecture
 ===
 
@@ -275,5 +291,43 @@ or
     - name: Wait for task to finish
       async_wait:
         job: async_task_obj
+        retries: 100
+        delay: 5
+
+async_task
+===
+
+The main task to create named async jobs.
+
+    ---
+    - name: Async recoverable job blah
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 10
+        alias: blah
+        async: 1000
+        retries: 100
+        delay: 5
+
+Is a replacement for:
+
+    - name: Find if the task exists
+      async_status_id: alias=blah
+      register: job_result
+    - name: Async job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 0
+      register: async_task_obj
+      when: not job_result.started
+    - name: Register task alias
+      async_alias: job=async_task_obj alias=blah
+      when: not job_result.started
+    - name: Wait for task to finish
+      async_wait:
+        alias: blah
         retries: 100
         delay: 5

--- a/example-playbooks/async_extra/README.md
+++ b/example-playbooks/async_extra/README.md
@@ -1,0 +1,199 @@
+Ansible asynchronous named jobs
+===
+
+The set of modules and plugins offers the mechanism to organize
+named jobs on top of the Ansible standard async architecture. It
+is fully compatible with Ansible native async wrapper and status.
+
+Architecture
+===
+
+Ansible native
+---
+
+Ansible async uses the following folder by default for storing
+jobs states:
+
+- `~/.ansible_async`
+
+The jobs usually have ID called `JID = random hex + '.' + parent id (pid)`.
+A job state is kept in files such as:
+
+    ~/.ansible_async/959330701595.43243
+
+and contain json objects. A json looks like the following for the
+finished jobs:
+
+    {
+        "cmd": "echo Hello &&\nsleep 10\n",
+        "stdout": "Hello",
+        "stderr": "",
+        "rc": 0,
+        "start": "2021-05-14 18:00:36.164859",
+        "end": "2021-05-14 18:00:46.169185",
+        "delta": "0:00:10.004326",
+        "changed": true,
+        "invocation": {
+            "module_args": {
+                "_raw_params": "echo Hello &&\nsleep 10\n",
+                "_uses_shell": true,
+                "warn": false,
+                "stdin_add_newline": true,
+                "strip_empty_ends": true,
+                "argv": null,
+                "chdir": null,
+                "executable": null,
+                "creates": null,
+                "removes": null,
+                "stdin": null
+            }
+        }
+    }
+
+and the following for just started ones:
+
+    {"started": 1, "finished": 0, "ansible_job_id": "454921468804.48399"}
+
+While the wrapper is working it keeps `${jid}.tmp` file near the state file.
+
+These modules
+---
+
+We define a job name (alias) as a soft-link to the job state:
+
+    ${jid}.jid_${alias} -> ${jid}
+
+General algorithm is:
+
+1. Find job by name
+2. If (1) is false: execute new async job
+3. If (1) is false: register job alias (name)
+4. Wait for job to finish
+5. Cleanup finished job alias if needed
+
+Job states
+---
+
+- Started: started == 1
+- Finished: finished == 1 or no started field in the job's state
+- Killed: killed == True
+- Started but pid_missing == True and unfinished
+
+Ansible addons architecture
+===
+
+            Caller site    |  Remote
+                           |
+    Task -> Action plugin --> Module
+
+Action plugins usually verify arguments, prepare execution context,
+and call other actions and modules. Actions execute on the caller site.
+If the action plugin is missing a task can directly call a module.
+A module has JSON API.
+
+For example:
+
+    - async_status_id: alias="blah"
+
+Calls action plugin `action_plugin/async_status_id.py` that in its turn
+calls a module `library/async_status_id.py`.
+
+async_status_id
+===
+
+This component gets the status of an asynchronous task. It can find
+a task's job by its name (alias).
+
+Features:
+
+- lookup by job name (alias)
+- killed jobs support (killed)
+- always checks that the wrapper is alive and running (pid_missing)
+- always outputs started and finished fields
+- default `cleanup` mode cleanups only an alias if the job was specified
+  by its name. if it was specified by a jid it deletes the whole state.
+
+Quick start
+---
+
+Simplest usage:
+
+    - name: Find out if the task exists
+      async_status_id: alias="blah"
+      register: job_result
+
+Example
+---
+
+Possible implementation of the named recoverable jobs with this component alone:
+
+    - name: Find if the task exists
+      async_status_id: alias="blah"
+      register: job_result
+    - name: Execute an async job Blah
+      shell: |
+        echo Hello &&
+        sleep 60
+      async: 1000
+      poll: 0
+      register: async_task_obj
+      when: not job_result.started
+    - name: Register task alias
+      file:
+        src: "{{ async_task_obj.results_file }}"
+        dest: "{{ async_task_obj.results_file | dirname }}/jid_blah"
+        state: link
+      when: not job_result.started
+    - name: Wait for task to finish
+      async_status_id: alias="blah"
+      register: job_result
+      until: job_result.finished
+      retries: 100
+      delay: 5
+    - name: Cleanup
+      async_status_id:
+        alias: "blah"
+        mode: "cleanup"
+
+This implementation do not handle overwrite of the aliases from other jobs
+at the step of registering a job alias. Neither it handles killed jobs.
+
+Example
+---
+
+An example shows an implementation of simple wait for an async job.
+
+    - name: Async task
+      shell: |
+      echo Hello &&
+      sleep 60
+      async: 1000
+      poll: 0
+      register: async_task_obj
+
+    - name: Wait for asynchronous job to end
+      async_status_id:
+      jid: '{{ async_task_obj.ansible_job_id }}'
+      register: job_result
+      until: job_result.finished
+      retries: 100
+      delay: 10
+   
+Debug
+---
+
+Actions may be executed via the `ansible-playground` with:
+
+    $ ansible-playbook -vvvv ./async_status_id_recoverable.yml
+
+Additional debug output can be enabled via:
+
+    $ ANSIBLE_DEBUG=true ansible-playbook -vvvv ./async_status_id_recoverable.yml
+
+Module alone can be tested with:
+
+    $ ./test_async_status_id.sh blah
+
+or
+
+    $ echo "{ \"ANSIBLE_MODULE_ARGS\": { \"alias\": \"$1\", \"_async_dir\": \"$HOME/.ansible_async\" } }" | PYTHONPATH=library python -m async_status_id

--- a/example-playbooks/async_extra/README.md
+++ b/example-playbooks/async_extra/README.md
@@ -245,3 +245,35 @@ Simple example:
 
     - async_alias: job=async_task_obj alias=blah
       when: not job_result.started
+
+async_wait
+===
+
+Waits an async job to finish, fail or being killed. By default, cleanups the
+job alias after it is finished.
+
+Arguments: {jid, alias, job}, cleanup = True, retries, delay.
+
+Examples:
+
+    - name: Wait for task to finish
+      async_wait:
+        alias: blah
+        retries: 100
+        delay: 5
+
+or 
+
+    - name: Wait for task to finish
+      async_wait:
+        jid: "{{async_task_obj.ansible_job_id}}"
+        retries: 100
+        delay: 5
+
+or 
+
+    - name: Wait for task to finish
+      async_wait:
+        job: async_task_obj
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/README.md
+++ b/example-playbooks/async_extra/README.md
@@ -331,3 +331,26 @@ Is a replacement for:
         alias: blah
         retries: 100
         delay: 5
+
+async_kill
+===
+
+Kill started job. 
+
+Kills job wrapper by sending SIGTERM (15) to the wrapper group (killpg).
+
+The status will be reported killed == 1 and finished == 0 and started == 1.
+
+    ---
+    - hosts: localhost
+      tasks:
+      - name: Task to kill
+        async_task:
+          shell: |
+            echo Hello &&
+            sleep 3600
+          alias: blah
+          async: 3600
+      - name: Kill job
+        async_kill:
+          alias: blah

--- a/example-playbooks/async_extra/action_plugins/async_alias.py
+++ b/example-playbooks/async_extra/action_plugins/async_alias.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.action import ActionBase
+from ansible.utils.vars import merge_hash
+
+import os
+
+
+class ActionModule(ActionBase):
+    _VALID_ARGS = frozenset(['job', 'alias'])
+
+    def run(self, tmp=None, task_vars=None):
+        results = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        if "job" not in self._task.args:
+            raise AnsibleError("job is required")
+
+        if "alias" not in self._task.args:
+            raise AnsibleError("job alias is required")
+
+        alias = self._task.args["alias"]
+        job = self._task.args["job"]
+        if job not in task_vars['vars']:
+            raise AnsibleError("no job among facts")
+        job = task_vars['vars'][job]
+        if "results_file" not in job:
+            raise AnsibleError("job does not contain results file")
+
+        module_args = dict(
+            src=job['results_file'],
+            dest=os.path.join(os.path.dirname(job['results_file']), "jid_" + alias),
+            state="link"
+        )
+        status = self._execute_module(module_name='ansible.legacy.file', task_vars=task_vars,
+                                      module_args=module_args)
+        results = merge_hash(results, status)
+        return results

--- a/example-playbooks/async_extra/action_plugins/async_kill.py
+++ b/example-playbooks/async_extra/action_plugins/async_kill.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import signal
+
+from ansible.errors import AnsibleError
+from ansible.plugins.action import ActionBase
+from ansible.utils.vars import merge_hash
+
+
+class ActionModule(ActionBase):
+
+    _VALID_ARGS = frozenset(('jid', 'alias', 'signal'))
+
+    def run(self, tmp=None, task_vars=None):
+        results = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        jid = ""
+        if "jid" in self._task.args:
+            jid = self._task.args["jid"]
+
+        alias = ""
+        if "alias" in self._task.args:
+            alias = self._task.args["alias"]
+
+        sig = self._task.args.get("signal", signal.SIGTERM)
+
+        if not jid and not alias:
+            raise AnsibleError("jid or alias is required")
+
+        env_async_dir = [e for e in self._task.environment if
+                         "ANSIBLE_ASYNC_DIR" in e]
+        if len(env_async_dir) > 0:
+            # for backwards compatibility we need to get the dir from
+            # ANSIBLE_ASYNC_DIR that is defined in the environment. This is
+            # deprecated and will be removed in favour of shell options
+            async_dir = env_async_dir[0]['ANSIBLE_ASYNC_DIR']
+
+            msg = "Setting the async dir from the environment keyword " \
+                  "ANSIBLE_ASYNC_DIR is deprecated. Set the async_dir " \
+                  "shell option instead"
+            self._display.deprecated(msg, "2.12", collection_name='ansible.builtin')
+        else:
+            # inject the async directory based on the shell option into the
+            # module args
+            async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
+
+        module_args = dict(signal=sig, _async_dir=async_dir)
+        if jid:
+            module_args['jid'] = jid
+        if alias:
+            module_args['alias'] = alias
+
+        status = self._execute_module(module_name='async_kill', task_vars=task_vars,
+                                      module_args=module_args)
+        results = merge_hash(results, status)
+
+        return results

--- a/example-playbooks/async_extra/action_plugins/async_status_id.py
+++ b/example-playbooks/async_extra/action_plugins/async_status_id.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.action import ActionBase
+from ansible.utils.vars import merge_hash
+
+
+class ActionModule(ActionBase):
+
+    _VALID_ARGS = frozenset(('jid', 'alias', 'mode'))
+
+    def run(self, tmp=None, task_vars=None):
+        results = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        jid = ""
+        if "jid" in self._task.args:
+            jid = self._task.args["jid"]
+
+        alias = ""
+        if "alias" in self._task.args:
+            alias = self._task.args["alias"]
+
+        mode = self._task.args.get("mode", "status")
+
+        if not jid and not alias:
+            raise AnsibleError("jid or alias is required")
+
+        env_async_dir = [e for e in self._task.environment if
+                         "ANSIBLE_ASYNC_DIR" in e]
+        if len(env_async_dir) > 0:
+            # for backwards compatibility we need to get the dir from
+            # ANSIBLE_ASYNC_DIR that is defined in the environment. This is
+            # deprecated and will be removed in favour of shell options
+            async_dir = env_async_dir[0]['ANSIBLE_ASYNC_DIR']
+
+            msg = "Setting the async dir from the environment keyword " \
+                  "ANSIBLE_ASYNC_DIR is deprecated. Set the async_dir " \
+                  "shell option instead"
+            self._display.deprecated(msg, "2.12", collection_name='ansible.builtin')
+        else:
+            # inject the async directory based on the shell option into the
+            # module args
+            async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
+
+        module_args = dict(mode=mode, _async_dir=async_dir)
+        if jid:
+            module_args['jid'] = jid
+        if alias:
+            module_args['alias'] = alias
+
+        status = self._execute_module(module_name='async_status_id', task_vars=task_vars,
+                                      module_args=module_args)
+        results = merge_hash(results, status)
+
+        return results

--- a/example-playbooks/async_extra/action_plugins/async_task.py
+++ b/example-playbooks/async_extra/action_plugins/async_task.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+from ansible.errors import AnsibleActionFail
+from ansible.plugins.action import ActionBase
+from ansible.executor.task_result import TaskResult
+from ansible.inventory.host import Host
+
+DOCUMENTATION = r'''
+---
+plugin: async_task
+short_description: Runs asynchronous recoverable job
+description: This is a replacement for:
+
+    - name: Find and wait for task if it exists
+      async_status_id: alias=blah
+      register: job_result
+    - name: Async job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 0
+      register: async_task_obj
+      when: not job_result.started
+    - name: Register task alias
+      async_alias: job=async_task_obj alias=blah
+      when: not job_result.started
+    - name: Wait for task to finish
+      async_wait:
+        alias: blah
+        retries: 100
+        delay: 5
+
+author:
+- Ivan Prisyazhnyy, ScyllaDB <ivan@scylladb.com>
+'''
+
+EXAMPLES = r'''
+---
+- name: Async recoverable job blah
+  async_task:
+    shell: |
+      echo Hello &&
+      sleep 10
+    alias: blah
+    async: 1000
+    retries: 100
+    delay: 5
+'''
+
+RETURN = r'''
+ansible_job_id:
+  description: The asynchronous job id
+  returned: success
+  type: str
+  sample: '360874038559.4169'
+finished:
+  description: Whether the asynchronous job has finished (C(1)) or not (C(0))
+  returned: success
+  type: int
+  sample: 1
+started:
+  description: Whether the asynchronous job has been started (C(1)) or not (C(0))
+  returned: success
+  type: int
+  sample: 1
+'''
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        alias = self._task.args.get("alias", "")
+        if not alias:
+            raise AnsibleActionFail("alias is required")
+
+        if 'async' not in self._task.args:
+            raise AnsibleActionFail("async is required")
+
+        running = self.find_running_task(alias, task_vars)
+        if is_failed(running):
+            result.update(running)
+            return result
+
+        if running['started'] != 1:
+            obj = self.run_async_task(task_vars)
+            if is_failed(result):
+                result.update(obj)
+                return result
+
+            obj = self.reg_async_task(obj['ansible_job_id'], alias, task_vars)
+            if is_failed(obj):
+                result.update(obj)
+                return result
+        else:
+            task = self._task.copy()
+            task.name = self._task.name + " - execute async job"
+            self.v2_on_result(Host(), task, {'skipped': 1})
+            task.name = self._task.name + " - register async job"
+            self.v2_on_result(Host(), task, {'skipped': 1})
+
+        retries = int(self._task.args.get('retries', 0))
+        delay = int(self._task.args.get('delay', 0))
+        poll = int(self._task.args.get('poll', 0))
+
+        if retries or delay:
+            if poll:
+                raise AnsibleActionFail("poll is not supported together with retries or delay")
+
+            result.update(self.wait_async_task(
+                alias=alias,
+                cleanup=self._task.args.get('cleanup', True),
+                retries=retries,
+                delay=delay,
+                vars=task_vars
+            ))
+        elif poll:
+            raise AnsibleActionFail("poll is not supported yet")
+
+        return result
+
+    def find_running_task(self, alias, vars):
+        task = self._task.copy()
+        task.name = self._task.name + " - lookup existing job"
+        task.args = {'alias': alias}
+        task._ds = {
+            "name": task.name,
+            "async_status_id": {
+                "alias": alias
+            }
+        }
+
+        handler = self._shared_loader_obj.action_loader.get('async_status_id',
+                                                            task=task,
+                                                            connection=self._connection,
+                                                            play_context=self._play_context,
+                                                            loader=self._loader,
+                                                            templar=self._templar,
+                                                            shared_loader_obj=self._shared_loader_obj)
+        result = handler.run(task_vars=vars)
+        return self.v2_on_result(Host(), task, result)
+
+    def run_async_task(self, vars):
+        task = self._task.copy()
+        task.name = self._task.name + " - execute async job"
+
+        task.async_val = int(task.args['async'])
+        task.args.pop('async')
+
+        if 'poll' in task.args:
+            task.poll = int(task.args['poll'])
+            task.args.pop('poll')
+
+        if 'shell' in task.args:
+            task.args['_raw_params'] = task.args['shell']
+            # Shell module is implemented via command with a special arg
+            task.args['_uses_shell'] = True
+            task.args.pop('shell')
+
+        allowed = ('_raw_params', '_uses_shell', 'argv', 'chdir', 'executable', 'creates', 'removes', 'warn', 'stdin',
+                   'stdin_add_newline', 'strip_empty_ends')
+
+        for item in list(task.args.keys()):
+            if item not in allowed:
+                task.args.pop(item)
+
+        handler = self._shared_loader_obj.action_loader.get('ansible.legacy.command',
+                                                            task=task,
+                                                            connection=self._connection,
+                                                            play_context=self._play_context,
+                                                            loader=self._loader,
+                                                            templar=self._templar,
+                                                            shared_loader_obj=self._shared_loader_obj)
+        result = handler.run(task_vars=vars)
+        return self.v2_on_result(Host(), task, result)
+
+    def reg_async_task(self, jid, alias, vars):
+        task = self._task.copy()
+        task.name = self._task.name + " - register async job"
+        task.args = {'alias': alias, 'jid': jid}
+        task._ds = {
+            "name": task.name,
+            "async_alias": {
+                "alias": alias,
+                "jid": jid
+            }
+        }
+
+        handler = self._shared_loader_obj.action_loader.get('async_alias',
+                                                            task=task,
+                                                            connection=self._connection,
+                                                            play_context=self._play_context,
+                                                            loader=self._loader,
+                                                            templar=self._templar,
+                                                            shared_loader_obj=self._shared_loader_obj)
+        result = handler.run(task_vars=vars)
+        return self.v2_on_result(Host(), task, result)
+
+    def wait_async_task(self, alias, cleanup, retries, delay, vars):
+        task = self._task.copy()
+        task.name = self._task.name + " - wait async job"
+        task.args = {
+            'alias': alias,
+            'cleanup': cleanup,
+            'retries': retries,
+            'delay': delay
+        }
+        task._ds = {
+            "name": task.name,
+            "async_wait": task.args.copy()
+        }
+        task.retries = retries
+        task.delay = delay
+
+        handler = self._shared_loader_obj.action_loader.get('async_wait',
+                                                            task=task,
+                                                            connection=self._connection,
+                                                            play_context=self._play_context,
+                                                            loader=self._loader,
+                                                            templar=self._templar,
+                                                            shared_loader_obj=self._shared_loader_obj)
+        result = handler.run(task_vars=vars)
+        return self.v2_on_result(Host(), task, result)
+
+    def v2_on_result(self, host, task, result):
+        handler = self._shared_loader_obj.callback_loader.get('default')
+        handler._display = self._display
+        handler.display_ok_hosts = True
+        handler.display_failed_stderr = True
+        handler.display_skipped_hosts = True
+
+        payload = TaskResult(host=host, task=task, return_data=result, task_fields=self._task.dump_attrs())
+
+        if 'failed' in result and result['failed']:
+            handler.set_option('show_task_path_on_failure', True)
+            # do nothing, because the failed result will be passed to the parent task
+            # handler.v2_runner_on_failed(payload)
+        elif 'skipped' in result and result['skipped']:
+            handler.v2_runner_on_skipped(payload)
+        else:
+            handler.v2_runner_on_ok(payload)
+
+        return result
+
+
+def is_failed(result):
+    return 'failed' in result and result['failed']
+

--- a/example-playbooks/async_extra/action_plugins/async_wait.py
+++ b/example-playbooks/async_extra/action_plugins/async_wait.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import time
+import json
+
+from ansible import constants as C
+from ansible.errors import AnsibleConnectionFailure, AnsibleActionFail, AnsibleActionSkip
+from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.module_utils.six import PY3
+from ansible.module_utils.six.moves import xrange
+from ansible.parsing.ajson import AnsibleJSONEncoder
+from ansible.plugins.action import ActionBase
+from ansible.vars.clean import strip_internal_keys, module_response_deepcopy
+
+if PY3:
+    # OrderedDict is needed for a backwards compat shim on Python3.x only
+    # https://github.com/ansible/ansible/pull/49512
+    from collections import OrderedDict
+else:
+    OrderedDict = None
+
+
+class TaskTimeoutError(BaseException):
+    pass
+
+
+DOCUMENTATION = r'''
+---
+plugin: async_wait 
+short_description: Awaits for a job to finish
+notes:
+- By default cleanups the job alias after it self if successful
+author:
+- Ivan Prisyazhnyy, ScyllaDB <ivan@scylladb.com>
+'''
+
+
+class ActionModule(ActionBase):
+    _VALID_ARGS = frozenset(['jid', 'alias', 'job', 'cleanup', 'retries', 'delay'])
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        jid = self._task.args.get("jid", "")
+        alias = self._task.args.get("alias", "")
+        job = self._task.args.get("job", "")
+        retries = int(self._task.args.get("retries", 1))
+        delay = int(self._task.args.get("delay", 0))
+        cleanup = boolean(self._task.args.get("cleanup", True))
+
+        if not jid and not alias and not job:
+            raise AnsibleActionFail("one of [jid, alias, job] is required")
+
+        if not retries:
+            raise AnsibleActionFail("retries is required")
+
+        if not delay:
+            raise AnsibleActionFail("delay is required")
+
+        if job:
+            if job not in task_vars['vars']:
+                raise AnsibleActionFail("no job among facts")
+            job = task_vars['vars'][job]
+            if "ansible_job_id" not in job:
+                raise AnsibleActionFail("job does not contain results file")
+            jid = job["ansible_job_id"]
+
+        if not jid and not alias:
+            raise AnsibleActionFail("jid or alias is required")
+
+        # wait
+        wait_task = self._task.copy()
+        wait_task.args = dict(mode="status")
+        if alias:
+            wait_task.args["alias"] = alias
+        if jid:
+            wait_task.args["jid"] = jid
+
+        # wait_task.retries copied from self._task
+        # wait_task.delay copied from self._task
+
+        def wait_until(x):
+            if not is_started(x):
+                raise AnsibleActionFail("job did not start")
+            return is_finished(x) or is_failed(x) or is_killed(x)
+
+        wait_action = self._shared_loader_obj.action_loader.get('async_status_id',
+                                                                task=wait_task,
+                                                                connection=self._connection,
+                                                                play_context=self._play_context,
+                                                                loader=self._loader,
+                                                                templar=self._templar,
+                                                                shared_loader_obj=self._shared_loader_obj)
+        result.update(self.retry(action=wait_action, vars=task_vars,
+                                 retries=retries, delay=delay,
+                                 until=lambda x: wait_until(x)))
+
+        # cleanup
+        if not is_failed(result) and cleanup:
+            cleanup_task = self._task.copy()
+            cleanup_task.retries = 0
+            cleanup_task.delay = 0
+            cleanup_task.args = dict(mode="cleanup")
+            if alias:
+                cleanup_task.args["alias"] = alias
+            if jid:
+                cleanup_task.args["jid"] = jid
+            self._shared_loader_obj.action_loader.get('async_status_id',
+                                                      task=cleanup_task,
+                                                      connection=self._connection,
+                                                      play_context=self._play_context,
+                                                      loader=self._loader,
+                                                      templar=self._templar,
+                                                      shared_loader_obj=self._shared_loader_obj) \
+                .run(task_vars=task_vars)
+            result['cleanup'] = True
+
+        return result
+
+    # copied from ansible
+    def _dump_results(self, result, indent=None, sort_keys=True, keep_invocation=False):
+        if not indent and (result.get('_ansible_verbose_always') or self._display.verbosity > 2):
+            indent = 4
+
+        # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.
+        abridged_result = strip_internal_keys(module_response_deepcopy(result))
+
+        # remove invocation unless specifically wanting it
+        if not keep_invocation and self._display.verbosity < 3 and 'invocation' in result:
+            del abridged_result['invocation']
+
+        # remove diff information from screen output
+        if self._display.verbosity < 3 and 'diff' in result:
+            del abridged_result['diff']
+
+        # remove exception from screen output
+        if 'exception' in abridged_result:
+            del abridged_result['exception']
+
+        try:
+            jsonified_results = json.dumps(abridged_result, cls=AnsibleJSONEncoder, indent=indent, ensure_ascii=False,
+                                           sort_keys=sort_keys)
+        except TypeError:
+            # Python3 bug: throws an exception when keys are non-homogenous types:
+            # https://bugs.python.org/issue25457
+            # sort into an OrderedDict and then json.dumps() that instead
+            if not OrderedDict:
+                raise
+            jsonified_results = json.dumps(OrderedDict(sorted(abridged_result.items(), key=to_text)),
+                                           cls=AnsibleJSONEncoder, indent=indent,
+                                           ensure_ascii=False, sort_keys=False)
+        return jsonified_results
+
+    # copied from ansible
+    def _run_is_verbose(self, result, verbosity=0):
+        return ((self._display.verbosity > verbosity or result.get('_ansible_verbose_always', False) is True)
+                and result.get('_ansible_verbose_override', False) is False)
+
+    # copied from ansible
+    def v2_runner_retry(self, result):
+        task_name = self._task.name
+        msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name, result['retries'] - result['attempts'])
+        if self._run_is_verbose(result, verbosity=2):
+            msg += "Result was: %s" % self._dump_results(result)
+        self._display.display(msg, color=C.COLOR_DEBUG)
+
+    # derived from ansible
+    def retry(self, action, vars, retries, delay, until):
+        if retries is None:
+            retries = 3
+        elif retries <= 0:
+            retries = 1
+
+        if delay < 0:
+            delay = 1
+
+        self._display.debug("starting attempt loop")
+        result = None
+        for attempt in xrange(1, retries + 1):
+            self._display.debug("running the action")
+            try:
+                result = action.run(task_vars=vars)
+            except AnsibleActionSkip as e:
+                return dict(skipped=True, msg=to_text(e))
+            except AnsibleActionFail as e:
+                return dict(failed=True, msg=to_text(e))
+            except AnsibleConnectionFailure as e:
+                return dict(unreachable=True, msg=to_text(e))
+            except TaskTimeoutError as e:
+                msg = 'The %s action failed to execute in the expected time frame (%d) and was terminated' % (
+                    self._task.action, self._task.timeout)
+                return dict(failed=True, msg=msg)
+            self._display.debug("action run complete")
+
+            # set the failed property if it was missing.
+            if 'failed' not in result:
+                # rc is here for backwards compatibility and modules that use it instead of 'failed'
+                if 'rc' in result and result['rc'] not in [0, "0"]:
+                    result['failed'] = True
+                else:
+                    result['failed'] = False
+
+            # Make attempts and retries available early to allow their use in changed/failed_when
+            result['attempts'] = attempt
+
+            # set the changed property if it was missing.
+            if 'changed' not in result:
+                result['changed'] = False
+
+            if retries > 1:
+                if until(result):
+                    break
+                else:
+                    # no conditional check, or it failed, so sleep for the specified time
+                    if attempt < retries:
+                        result['_ansible_retry'] = True
+                        result['retries'] = retries
+                        self._display.debug('Retrying task, attempt %d of %d' % (attempt, retries))
+                        self.v2_runner_retry(result)
+                        time.sleep(delay)
+        else:
+            if retries > 1:
+                # we ran out of attempts, so mark the result as failed
+                result['failed'] = True
+                result['attempts'] = retries - 1
+
+        if not is_failed(result) and not until(result):
+            result['failed'] = True
+            result['msg'] = "Ran out of attempts."
+
+        if not is_failed(result) and not is_finished(result):
+            result['failed'] = True
+            result['msg'] = "Job did not finish."
+
+        return result
+
+
+def is_started(x):
+    return 'started' in x and x['started']
+
+
+def is_finished(x):
+    return 'finished' in x and x['finished']
+
+
+def is_failed(x):
+    return 'failed' in x and x['failed']
+
+
+def is_killed(x):
+    return 'killed' in x and x['killed']
+

--- a/example-playbooks/async_extra/async_alias_recoverable.yml
+++ b/example-playbooks/async_extra/async_alias_recoverable.yml
@@ -1,4 +1,4 @@
-#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+#!/usr/sbin/ansible-playbook ./async_alias_recoverable.yml -vvvv
 # CTRL+C and try again.
 #
 # Example playbook.
@@ -35,10 +35,7 @@
       register: async_task_obj
       when: not job_result.started
     - name: Register task alias
-      file:
-        src: "{{ async_task_obj.results_file }}"
-        dest: "{{ async_task_obj.results_file | dirname }}/jid_blah"
-        state: link
+      async_alias: job=async_task_obj alias=blah
       when: not job_result.started
     - name: Wait for task to finish
       async_status_id: alias=blah

--- a/example-playbooks/async_extra/async_kill.yml
+++ b/example-playbooks/async_extra/async_kill.yml
@@ -1,0 +1,14 @@
+#!/usr/sbin/ansible-playbook ./async_kill.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Task to kill
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 3600
+        alias: blah
+        async: 3600
+    - name: Kill job
+      async_kill:
+        alias: blah

--- a/example-playbooks/async_extra/async_kill_status.yml
+++ b/example-playbooks/async_extra/async_kill_status.yml
@@ -1,0 +1,17 @@
+#!/usr/sbin/ansible-playbook ./async_kill.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Task to kill
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 3600
+        alias: blah
+        async: 3600
+    - name: Kill job
+      async_kill:
+        alias: blah
+    - name: Status - expect killed eq true
+      async_status_id:
+        alias: blah

--- a/example-playbooks/async_extra/async_kill_x2.yml
+++ b/example-playbooks/async_extra/async_kill_x2.yml
@@ -1,0 +1,17 @@
+#!/usr/sbin/ansible-playbook ./async_kill.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Task to kill
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 3600
+        alias: blah
+        async: 3600
+    - name: Kill job
+      async_kill:
+        alias: blah
+    - name: Kill job
+      async_kill:
+        alias: blah

--- a/example-playbooks/async_extra/async_status_id_recoverable.yml
+++ b/example-playbooks/async_extra/async_status_id_recoverable.yml
@@ -1,0 +1,55 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+# CTRL+C and try again.
+#
+# Example playbook.
+#
+# The playbook demonstrates how to simulate named jobs that can be
+# recovered on playbook restart with the only additional async_status_id
+# module.
+#
+# The algorithm is as follows:
+# 1. Find if there existing job by the name (alias)
+# 2. If the job does not exist we:
+#    2.1. Create a job
+#    2.2. Register it's name on a system
+# 3. If the job exists 2.x steps are skipped.
+# 4. Wait for the job to finish in max 100 tries with 5 secs delay retry.
+#    This specific example would fail a wait try if the job is killed or failed to finish.
+#    So that if the job is unfinished it will exhaust all trial attempts.
+# 5. Delete the job name.
+#    Names are soft-link to the job state.
+#    If the job name (alias) is deleted than you can start a new one.
+#    If you would not delete a job alias its possible to turn it into a singleton.
+---
+- hosts: localhost
+  tasks:
+    - name: Find if the task exists
+      async_status_id: alias="blah"
+      register: job_result
+    - name: Execute an async job Blah
+      shell: |
+        echo Hello &&
+        sleep 60
+      async: 1000
+      poll: 0
+      register: async_task_obj
+      when: not job_result.started
+    - name: Register task alias
+      file:
+        src: "{{ async_task_obj.results_file }}"
+        dest: "{{ async_task_obj.results_file | dirname }}/jid_blah"
+        state: link
+      when: not job_result.started
+    - name: Wait for task to finish
+      async_status_id: alias="blah"
+      register: job_result
+      until: job_result.finished
+      retries: 100
+      delay: 5
+    - name: Cleanup
+      async_status_id:
+        alias: "blah"
+        mode: "cleanup"
+    - name: Print final object
+      debug:
+        msg: "{{job_result}}"

--- a/example-playbooks/async_extra/async_status_id_recoverable_wait.yml
+++ b/example-playbooks/async_extra/async_status_id_recoverable_wait.yml
@@ -1,0 +1,23 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Find and wait for task if it exists
+      async_status_id: alias=blah
+      register: job_result
+    - name: Async job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 0
+      register: async_task_obj
+      when: not job_result.started
+    - name: Register task alias
+      async_alias: job=async_task_obj alias=blah
+      when: not job_result.started
+    - name: Wait for task to finish
+      async_wait:
+        alias: blah
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/async_task_failure.yml
+++ b/example-playbooks/async_extra/async_task_failure.yml
@@ -1,0 +1,12 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Failed async job
+      async_task:
+        shell: |
+          exit 1
+        alias: blah
+        async: 1000
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/async_task_failure_retries.yml
+++ b/example-playbooks/async_extra/async_task_failure_retries.yml
@@ -1,0 +1,13 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Failed async job
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 10
+        alias: blah
+        async: 1000
+        retries: 1
+        delay: 1

--- a/example-playbooks/async_extra/async_task_failure_timeout.yml
+++ b/example-playbooks/async_extra/async_task_failure_timeout.yml
@@ -1,0 +1,13 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Failed async job
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 10
+        alias: blah
+        async: 1
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/async_task_long.yml
+++ b/example-playbooks/async_extra/async_task_long.yml
@@ -1,0 +1,13 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Long running task
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 3600
+        alias: blah
+        async: 1000
+        retries: 720
+        delay: 5

--- a/example-playbooks/async_extra/async_task_long_poll.yml
+++ b/example-playbooks/async_extra/async_task_long_poll.yml
@@ -1,0 +1,12 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Check parent poll timeout
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 3600
+        alias: blah
+        async: 1000
+        poll: 5

--- a/example-playbooks/async_extra/async_task_no_wait.yml
+++ b/example-playbooks/async_extra/async_task_no_wait.yml
@@ -1,0 +1,11 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Do not wait for the task to finish
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 10
+        alias: blah
+        async: 1000

--- a/example-playbooks/async_extra/async_task_recoverable.yml
+++ b/example-playbooks/async_extra/async_task_recoverable.yml
@@ -1,0 +1,13 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Async recoverable job Blah
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 10
+        alias: blah
+        async: 1000
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/async_task_reg.yml
+++ b/example-playbooks/async_extra/async_task_reg.yml
@@ -1,0 +1,16 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Async recoverable job Blah
+      async_task:
+        shell: |
+          echo Hello &&
+          sleep 10
+        alias: blah
+        async: 1000
+        retries: 100
+        delay: 5
+      register: async_task_obj
+    - debug:
+        msg: "{{async_task_obj}}"

--- a/example-playbooks/async_extra/async_task_singleton.yml
+++ b/example-playbooks/async_extra/async_task_singleton.yml
@@ -1,0 +1,26 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+# The task runs asynchronously only once for all times per host in recoverable mode.
+# It would not be ever rerun since finished.
+---
+- hosts: localhost
+  tasks:
+    - name: Find and wait for task if it exists
+      async_status_id: alias=blah
+      register: job_result
+    - name: Async job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 0
+      register: async_task_obj
+      when: not job_result.started
+    - name: Register task alias
+      async_alias: job=async_task_obj alias=blah
+      when: not job_result.started
+    - name: Wait for task to finish
+      async_status_id: alias=blah
+      register: job_result
+      until: job_result.finished
+      retries: 100
+      delay: 5

--- a/example-playbooks/async_extra/async_wait_alias.yml
+++ b/example-playbooks/async_extra/async_wait_alias.yml
@@ -1,0 +1,23 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Find and wait for task if it exists
+      async_status_id: alias=blah
+      register: job_result
+    - name: Async job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 0
+      register: async_task_obj
+      when: not job_result.started
+    - name: Register task alias
+      async_alias: job=async_task_obj alias=blah
+      when: not job_result.started
+    - name: Wait for task to finish
+      async_wait:
+        alias: blah
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/async_wait_fake_alias.yml
+++ b/example-playbooks/async_extra/async_wait_fake_alias.yml
@@ -1,0 +1,9 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Wait for task to finish
+      async_wait:
+        alias: fake_blah
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/async_wait_jid.yml
+++ b/example-playbooks/async_extra/async_wait_jid.yml
@@ -1,0 +1,16 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Async job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 0
+      register: async_task_obj
+    - name: Wait for task to finish
+      async_wait:
+        jid: "{{async_task_obj.ansible_job_id}}"
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/async_wait_job.yml
+++ b/example-playbooks/async_extra/async_wait_job.yml
@@ -1,0 +1,16 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Async job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 0
+      register: async_task_obj
+    - name: Wait for task to finish
+      async_wait:
+        job: async_task_obj
+        retries: 100
+        delay: 5

--- a/example-playbooks/async_extra/library/async_kill.py
+++ b/example-playbooks/async_extra/library/async_kill.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+import json
+import os
+import signal
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.common.text.converters import to_native
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: async_kill
+short_description: Finds existing async job and kills it
+description:
+- This module gets the status of an asynchronous task.
+options:
+  jid:
+    description:
+    - Job or task identifier
+    type: str
+    optional: true
+  alias:
+    description:
+    - Job alias
+    type: str
+    optional: true
+  signal:
+    SIGTERM
+author:
+- Ivan Prisyazhnyy, ScyllaDB <ivan@scylladb.com>
+'''
+
+EXAMPLES = r'''
+---
+- name: Async task
+  shell: |
+    echo Hello &&
+    sleep 60
+  async: 1000
+  poll: 0
+  register: async_task_obj
+
+- name: Kill the job by id
+  async_kill:
+    jid: '{{ async_task_obj.ansible_job_id }}'
+'''
+
+RETURN = r'''
+ansible_job_id:
+  description: The asynchronous job id
+  returned: success
+  type: str
+  sample: '360874038559.4169'
+killed:
+  description: Whether the asynchronous job was killed (C(1)) or not (C(0))
+  returned: success
+  type: boolean 
+  sample: True
+'''
+
+
+def main():
+    module = AnsibleModule(argument_spec=dict(
+        jid=dict(type='str'),
+        alias=dict(type='str'),
+        signal=dict(type='int', default=signal.SIGTERM),
+        # passed in from the async_status action plugin
+        _async_dir=dict(type='path', required=True),
+    ),
+        required_one_of=[['jid', 'alias']],
+        mutually_exclusive=[['jid', 'alias']]
+    )
+
+    request = Request(module)
+    response = Response(request)
+
+    t = Tracker(module, response)
+    data = t.load_job_state(request.log_path)
+    module.debug("current state %s" % data)
+    t.update_state(data)
+
+    if response.finished:
+        module.debug("job is finished. nothing to kill.")
+        module.exit_json(**response.__dict__)
+
+    if response.killed:
+        module.debug("job has been killed previously. nothing to kill.")
+        module.exit_json(**response.__dict__)
+
+    pid = t.get_jid_pid(request.jid)
+    alive = [pid]
+    if not t.is_pid_alive(pid):
+        alive = find_pid(request.jid)
+        if not alive:
+            module.debug("job is unfinished and no wrapper alive. nothing to kill.")
+            module.exit_json(**response.__dict__)
+
+    # kill
+    module.debug("alive pids = %s" % alive)
+
+    data['killed'] = True
+    prepare_state_update(request.log_path, data, "kill")
+
+    for pid in alive:
+        module.debug("killing group pid = %d, sig = %d" % (pid, request.signal))
+        t.kill_all(pid, request.signal)
+
+    commit_state_update(request.log_path, "kill")
+    # cleanup running wrapper marker
+    try_cleanup_state_update(request.log_path, "tmp")
+    response.killed = True
+
+    module.exit_json(**response.__dict__)
+
+
+class Request:
+    def __init__(self, module):
+        self.jid = module.params.get('jid')
+        self.alias = module.params.get('alias')
+        self.signal = int(module.params.get('signal', signal.SIGTERM))
+        self.async_dir = module.params['_async_dir']
+        self.log_dir = os.path.expanduser(self.async_dir)
+        self.log_path = ""
+        self.alias_path = ""
+
+        self.parse(module)
+
+    def parse(self, module):
+        if self.jid:
+            self.log_path = os.path.join(self.log_dir, self.jid)
+            if not os.path.exists(self.log_path):
+                module.fail_json(msg="could not find job", **Response(self).__dict__)
+        elif self.alias:
+            self.alias_path = os.path.join(self.log_dir, "jid_" + self.alias)
+            self.log_path = self.alias_path
+            if not os.path.exists(self.log_path):
+                module.exit_json(**Response(self).__dict__)
+            # follow symlink
+            self.log_path = os.readlink(self.alias_path)
+            self.jid = os.path.basename(self.log_path)
+            if not os.path.exists(self.log_path):
+                module.fail_json(msg="could not find job", **Response(self).__dict__)
+        else:
+            module.fail_json(msg="could not find job", **Response(self).__dict__)
+
+
+class Response:
+    def __init__(self, request):
+        self.ansible_job_id = request.jid
+        self.ansible_job_alias = request.alias
+        self.started = 0
+        self.finished = 0
+        self.killed = False
+        self.log_path = request.log_path
+        self.alias_path = request.alias_path
+
+    def merge(self, data):
+        self.__dict__ = {**self.__dict__, **data}
+
+
+class Tracker:
+    def __init__(self, module, response):
+        self.module = module
+        self.response = response
+
+    def load_job_state(self, log_path):
+        data = None
+        try:
+            with open(log_path) as f:
+                data = json.loads(f.read())
+        except Exception:
+            if not data:
+                # file not written yet?  That means it is running
+                self.module.exit_json(**self.response.__dict__)
+            else:
+                self.module.fail_json(msg="Could not parse job output: %s" % data, **self.response.__dict__)
+
+        return data
+
+    def update_state(self, data):
+        # semantics: if log file exists then the job has been started
+        self.response.merge(data)
+        self.response.started = 1
+        if 'started' not in data:
+            self.response.finished = 1
+        elif 'finished' not in data:
+            self.response.finished = 0
+
+    def get_jid_pid(self, jid):
+        s = str(jid).split('.')
+        if len(s) != 2:
+            self.module.fail_json(msg="Unexpected jid format: %s" % jid, **self.response.__dict__)
+        return int(s[1])
+
+    def is_pid_alive(self, pid):
+        try:
+            os.kill(pid, 0)
+        except OSError as err:
+            import errno
+
+            if err.errno == errno.ESRCH:
+                return False
+            elif err.errno == errno.EPERM:
+                self.module.fail_json(msg="No permission to signal this process: %d" % pid, **self.response.__dict__)
+            else:
+                self.module.fail_json(msg="Unknown error: %s" % err, **self.response.__dict__)
+
+        return True
+
+    def kill_all(self, gpid, sig):
+        try:
+            os.killpg(gpid, sig)
+        except OSError as err:
+            import errno
+
+            if err.errno == errno.ESRCH:
+                return False
+            elif err.errno == errno.EPERM:
+                self.module.fail_json(msg="No permission to signal this process: %d <- %d" % (gpid, sig), **self.response.__dict__)
+            else:
+                self.module.fail_json(msg="Unknown error: %s" % err, **self.response.__dict__)
+
+        return True
+
+
+# {"started": 1, "finished": 0, "ansible_job_id": "5914760398.19030"}
+def prepare_state_update(log_path, state, suffix):
+    tmp_job_path = log_path + "." + suffix
+    jobfile = open(tmp_job_path, "w")
+    jobfile.write(json.dumps(state))
+    jobfile.close()
+
+
+def commit_state_update(log_path, suffix):
+    tmp_job_path = log_path + "." + suffix
+    os.rename(tmp_job_path, log_path)
+
+
+def try_cleanup_state_update(log_path, suffix):
+    tmp_job_path = log_path + "." + suffix
+    if os.path.isfile(tmp_job_path):
+        os.remove(tmp_job_path)
+
+
+def find_pid(jid):
+    import subprocess
+
+    search = "async_wrapper.py " + get_jid_id(jid)
+
+    ps = subprocess.Popen("ps --format=pid,ppid,pgid,cmd -e | grep '%s'" % search, shell=True, stdout=subprocess.PIPE)
+    output = ps.stdout.readlines()
+    ps.stdout.close()
+    ps.wait()
+
+    # 1 line is grep:
+    #     0 S xxxxxx     23516   17036  0  80   0 -  1761 -      12:46 pts/0    00:00:00 grep --color=auto 365913987461
+    # other 2 lines:
+    #     1 S xxxxxx     21099    2564  0  80   0 -  7450 -      12:31 ?        00:00:00 /usr/bin/python
+    #           /home/xxxxxx/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/async_wrapper.py
+    #           365913987461 3600 /home/sitano/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/
+    #           AnsiballZ_command.py _
+    #     1 S xxxxxx     21100   21099  0  80   0 -  7514 -      12:31 ?        00:00:00 /usr/bin/python
+    #           /home/xxxxxx/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/async_wrapper.py
+    #           365913987461 3600 /home/sitano/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/
+    #           AnsiballZ_command.py _
+
+    return [int(line.decode().split()[0]) for line in output if 'python' in str(line)]
+
+
+def get_jid_id(jid):
+    return str(jid).split('.')[0]
+
+
+if __name__ == '__main__':
+    main()

--- a/example-playbooks/async_extra/library/async_status_id.py
+++ b/example-playbooks/async_extra/library/async_status_id.py
@@ -168,7 +168,7 @@ def main():
     module = AnsibleModule(argument_spec=dict(
         jid=dict(type='str'),
         alias=dict(type='str'),
-        mode=dict(type='str', default='status', choices=['cleanup', 'status']),
+        mode=dict(type='str', default='status', choices=['full_cleanup', 'cleanup', 'status']),
         # passed in from the async_status action plugin
         _async_dir=dict(type='path', required=True),
     ),
@@ -185,6 +185,13 @@ def main():
     t.update_state(data)
 
     if request.mode == 'cleanup':
+        if request.alias:
+            os.unlink(request.alias_path)
+        elif request.jid:
+            os.unlink(request.log_path)
+        module.exit_json(erased=request.log_path, **response.data())
+
+    if request.mode == 'full_cleanup':
         os.unlink(request.log_path)
         module.exit_json(erased=request.log_path, **response.data())
 

--- a/example-playbooks/async_extra/library/async_status_id.py
+++ b/example-playbooks/async_extra/library/async_status_id.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+import json
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.common.text.converters import to_native
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: async_wait_id
+short_description: Finds existing async job by alias or id
+description:
+- This module gets the status of an asynchronous task.
+options:
+  jid:
+    description:
+    - Job or task identifier
+    type: str
+    optional: true
+  alias:
+    description:
+    - Job alias
+    type: str
+    optional: true
+  mode:
+    description:
+    - If C(status), obtain the status.
+    - If C(cleanup), clean up the async job cache (by default in C(~/.ansible_async/)) for the specified job I(jid).
+    type: str
+    choices: [ cleanup, status ]
+    default: status
+seealso:
+- ref: playbooks_async
+  description: Detailed information on how to use asynchronous actions and polling.
+author:
+- Ivan Prisyazhnyy, ScyllaDB <ivan@scylladb.com>
+'''
+
+EXAMPLES = r'''
+---
+- name: Async task
+  shell: |
+    echo Hello &&
+    sleep 60
+  async: 1000
+  poll: 0
+  register: async_task_obj
+
+- name: Wait for asynchronous job to end
+  async_status_id:
+    jid: '{{ async_task_obj.ansible_job_id }}'
+  register: job_result
+  until: job_result.finished
+  retries: 100
+  delay: 10
+  
+---
+- name: Find and wait for task if it exists
+  async_status_id: alias="blah"
+  register: job_result
+  
+- name: Async job Blah
+  shell: |
+    echo Hello &&
+    sleep 60
+  async: 1000
+  poll: 0
+  register: async_task_obj
+  when: not job_result.started
+  
+- name: Register task id
+  file:
+    src: "{{ async_task_obj.results_file }}"
+    dest: "{{ async_task_obj.results_file | dirname }}/jid_blah"
+    state: link
+  when: not job_result.started
+  
+- name: Wait for task to finish
+  async_status_id: alias="blah"
+  register: job_result
+  until: job_result.finished
+  retries: 100
+  delay: 5
+  
+- name: Cleanup
+  async_status_id:
+    alias: "blah"
+    mode: "cleanup"
+'''
+
+RETURN = r'''
+ansible_job_id:
+  description: The asynchronous job id
+  returned: success
+  type: str
+  sample: '360874038559.4169'
+finished:
+  description: Whether the asynchronous job has finished (C(1)) or not (C(0))
+  returned: success
+  type: int
+  sample: 1
+started:
+  description: Whether the asynchronous job has been started (C(1)) or not (C(0))
+  returned: success
+  type: int
+  sample: 1
+'''
+
+
+def main():
+    module = AnsibleModule(argument_spec=dict(
+        jid=dict(type='str'),
+        alias=dict(type='str'),
+        mode=dict(type='str', default='status', choices=['cleanup', 'status']),
+        # passed in from the async_status action plugin
+        _async_dir=dict(type='path', required=True),
+    ),
+        required_one_of=[['jid', 'alias']],
+        mutually_exclusive=[['jid', 'alias']]
+    )
+
+    request = Request(module)
+    response = Response(request)
+
+    t = Tracker(module, response)
+    data = t.load_job_state(request.log_path)
+    module.debug("current state %s" % data)
+    t.update_state(data)
+
+    if request.mode == 'cleanup':
+        os.unlink(request.log_path)
+        module.exit_json(erased=request.log_path, **response.data())
+
+    if response.killed:
+        module.exit_json(**response.data())
+
+    if not response.finished:
+        pid = t.get_jid_pid(request.jid)
+        if not t.is_pid_alive(pid):
+            if not find_pid(request.jid):
+                # recheck that the job did not finish while we were looking at the wrapper pid
+                data = t.load_job_state(request.log_path)
+                t.update_state(data)
+                if not response.finished:
+                    response.pid_missing = True
+                    module.fail_json(msg="can't find alive process." +
+                                         " probably async_wrapper.py wrapper unexpectedly died." +
+                                         " check how " + os.path.join(request.async_dir, request.jid) + " is doing." +
+                                         " if it is failed, delete the soft link (alias) to it.", **response.data())
+
+    module.exit_json(**response.data())
+
+
+class Request:
+    def __init__(self, module):
+        self.jid = module.params.get('jid')
+        self.alias = module.params.get('alias')
+        self.mode = module.params.get('mode', 'status')
+        self.async_dir = module.params['_async_dir']
+        self.log_dir = os.path.expanduser(self.async_dir)
+        self.log_path = ""
+        self.alias_path = ""
+
+        self.parse(module)
+
+    def parse(self, module):
+        if self.jid:
+            self.log_path = os.path.join(self.log_dir, self.jid)
+            if not os.path.exists(self.log_path):
+                module.fail_json(msg="could not find job", **Response(self).data())
+        elif self.alias:
+            self.alias_path = os.path.join(self.log_dir, "jid_" + self.alias)
+            self.log_path = self.alias_path
+            if not os.path.exists(self.log_path):
+                module.exit_json(**Response(self).data())
+            # follow symlink
+            self.log_path = os.readlink(self.alias_path)
+            self.jid = os.path.basename(self.log_path)
+            if not os.path.exists(self.log_path):
+                module.fail_json(msg="could not find job", **Response(self).data())
+        else:
+            module.fail_json(msg="could not find job", **Response(self).data())
+
+
+class Response:
+    def __init__(self, request):
+        self.ansible_job_id = request.jid
+        self.ansible_job_alias = request.alias
+        self.started = 0
+        self.finished = 0
+        self.killed = False
+        self.log_path = request.log_path
+        self.alias_path = request.alias_path
+
+    def merge(self, data):
+        self.__dict__ = {**self.__dict__, **data}
+
+    def data(self):
+        # Fix error: TypeError: exit_json() keywords must be strings
+        return dict([(to_native(k), v) for k, v in iteritems(self.__dict__)])
+
+
+class Tracker:
+    def __init__(self, module, response):
+        self.module = module
+        self.response = response
+
+    def load_job_state(self, log_path):
+        data = None
+        try:
+            with open(log_path) as f:
+                data = json.loads(f.read())
+        except Exception:
+            if not data:
+                # file not written yet?  That means it is running
+                self.module.exit_json(**self.response.data())
+            else:
+                self.module.fail_json(msg="Could not parse job output: %s" % data, **self.response.data())
+
+        return data
+
+    def update_state(self, data):
+        # semantics: if log file exists then the job has been started
+        self.response.merge(data)
+        self.response.started = 1
+        if 'started' not in data:
+            self.response.finished = 1
+        elif 'finished' not in data:
+            self.response.finished = 0
+
+    def get_jid_pid(self, jid):
+        s = str(jid).split('.')
+        if len(s) != 2:
+            self.module.fail_json(msg="Unexpected jid format: %s" % jid, **self.response.data())
+        return int(s[1])
+
+    def is_pid_alive(self, pid):
+        try:
+            os.kill(pid, 0)
+        except OSError as err:
+            import errno
+
+            if err.errno == errno.ESRCH:
+                return False
+            elif err.errno == errno.EPERM:
+                self.module.fail_json(msg="No permission to signal this process: %d" % pid, **self.response.data())
+            else:
+                self.module.fail_json(msg="Unknown error: %s" % err, **self.response.data())
+
+        return True
+
+
+def find_pid(jid):
+    import subprocess
+
+    search = "async_wrapper.py " + get_jid_id(jid)
+
+    ps = subprocess.Popen("ps --format=pid,ppid,pgid,cmd -e | grep '%s'" % search, shell=True, stdout=subprocess.PIPE)
+    output = ps.stdout.readlines()
+    ps.stdout.close()
+    ps.wait()
+
+    # 1 line is grep:
+    #     0 S xxxxxx     23516   17036  0  80   0 -  1761 -      12:46 pts/0    00:00:00 grep --color=auto 365913987461
+    # other 2 lines:
+    #     1 S xxxxxx     21099    2564  0  80   0 -  7450 -      12:31 ?        00:00:00 /usr/bin/python
+    #           /home/xxxxxx/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/async_wrapper.py
+    #           365913987461 3600 /home/sitano/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/
+    #           AnsiballZ_command.py _
+    #     1 S xxxxxx     21100   21099  0  80   0 -  7514 -      12:31 ?        00:00:00 /usr/bin/python
+    #           /home/xxxxxx/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/async_wrapper.py
+    #           365913987461 3600 /home/sitano/.ansible/tmp/ansible-tmp-1620901911.527596-21084-188005885689773/
+    #           AnsiballZ_command.py _
+
+    return [int(line.decode().split()[0]) for line in output if 'python' in str(line)]
+
+
+def get_jid_id(jid):
+    return str(jid).split('.')[0]
+
+
+if __name__ == '__main__':
+    main()

--- a/example-playbooks/async_extra/library/async_status_id.py
+++ b/example-playbooks/async_extra/library/async_status_id.py
@@ -113,6 +113,36 @@ EXAMPLES = r'''
   async_status_id:
     alias: "blah"
     mode: "cleanup"
+
+---
+- name: Find and wait for task if it exists
+  async_status_id: alias=blah
+  register: job_result
+  
+- name: Async job Blah
+  shell: |
+    echo Hello &&
+    sleep 10
+  async: 1000
+  poll: 0
+  register: async_task_obj
+  when: not job_result.started
+  
+- name: Register task alias
+  async_alias: job=async_task_obj alias=blah
+  when: not job_result.started
+  
+- name: Wait for task to finish
+  async_status_id: alias=blah
+  register: job_result
+  until: job_result.finished
+  retries: 100
+  delay: 5
+  
+- name: Cleanup
+  async_status_id:
+    alias: "blah"
+    mode: "cleanup"
 '''
 
 RETURN = r'''

--- a/example-playbooks/async_extra/shell.yml
+++ b/example-playbooks/async_extra/shell.yml
@@ -1,0 +1,11 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Async recoverable job Blah
+      shell: |
+        echo Hello &&
+        sleep 10
+      async: 1000
+      poll: 5
+      register: async_task_obj

--- a/example-playbooks/async_extra/test.yml
+++ b/example-playbooks/async_extra/test.yml
@@ -1,0 +1,10 @@
+#!/usr/bin/ansible-playbook --inventory=inventory.ini
+---
+- hosts: localhost
+  tasks:
+    - name: Blah
+      my_test:
+        name: lol
+        shell: |
+          echo 123 &&
+          sleep 60

--- a/example-playbooks/async_extra/test_async_kill.sh
+++ b/example-playbooks/async_extra/test_async_kill.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "{ \"ANSIBLE_MODULE_ARGS\": { \"alias\": \"$1\", \"_async_dir\": \"$HOME/.ansible_async\" } }" | PYTHONPATH=library python -m async_kill

--- a/example-playbooks/async_extra/test_async_status_id.sh
+++ b/example-playbooks/async_extra/test_async_status_id.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "{ \"ANSIBLE_MODULE_ARGS\": { \"alias\": \"$1\", \"_async_dir\": \"$HOME/.ansible_async\" } }" | PYTHONPATH=library python -m async_status_id


### PR DESCRIPTION
The set of modules and plugins offers the mechanism to organize
named jobs on top of the Ansible standard async architecture. It
is fully compatible with Ansible native async wrapper and status.

async_task
===

    ---
    - hosts: localhost
      tasks:
        - name: Async recoverable job blah
          async_task:
            shell: |
              echo Hello &&
              sleep 10
            alias: blah
            async: 1000
            retries: 100
            delay: 5

instead of
===

    ---
    - hosts: localhost
      tasks:
        - name: Find if the task exists
          async_status_id: alias=blah
          register: job_result
        - name: Async job Blah
          shell: |
            echo Hello &&
            sleep 10
          async: 1000
          poll: 0
          register: async_task_obj
          when: not job_result.started
        - name: Register task alias
          async_alias: job=async_task_obj alias=blah
          when: not job_result.started
        - name: Wait for task to finish
          async_wait:
            alias: blah
            retries: 100
            delay: 5

instead of
===

    ---
    - hosts: localhost
      tasks:
        - name: Find if the task exists
          async_status_id: alias=blah
          register: job_result
        - name: Execute an async job Blah
          shell: |
            echo Hello &&
            sleep 10
          async: 1000
          poll: 0
          register: async_task_obj
          when: not job_result.started
        - name: Register task alias
          file:
            src: "{{ async_task_obj.results_file }}"
            dest: "{{ async_task_obj.results_file | dirname }}/jid_blah"
            state: link
          when: not job_result.started
        - name: Wait for task to finish
          async_status_id: alias=blah
          register: job_result
          until: job_result.finished
          retries: 100
          delay: 5
        - name: Cleanup
          async_status_id:
            alias: "blah"
            mode: "cleanup"
        - name: Print final object
          debug:
            msg: "{{job_result}}"

TODO
---
- check other command module modes
- test on remotes