### PR TITLE
Async script

### DIFF
--- a/example-playbooks/async_extra/README.md
+++ b/example-playbooks/async_extra/README.md
@@ -332,6 +332,25 @@ Is a replacement for:
         retries: 100
         delay: 5
 
+Temporary files
+---
+
+`async_task` does not cleanup temporary directory resulting from
+the execution of the async job because the lifetime of the async
+job is disconnected from the modules/plugins lifetime.
+
+Failures
+---
+
+If the execution of the `async_task` async job finishes with a bad
+result the task will NOT cleanup the job _alias_ because it may
+not know what is the correct way of recover from the previous job
+bad state.
+
+To be able to restart such a job the state must be cleaned up
+manually by at least erasing (`rm`) the job's _alias_ from the
+ansible async wrapper directory: by default `~/.ansible_async/`.
+
 async_kill
 ===
 

--- a/example-playbooks/async_extra/README.md
+++ b/example-playbooks/async_extra/README.md
@@ -21,6 +21,17 @@ Quick start
         retries: 100
         delay: 5
 
+or 
+
+    ---
+    - name: Long running task
+      async_task:
+        script: sleep.sh 10
+        alias: blah
+        async: 1000
+        retries: 720
+        delay: 5
+
 Architecture
 ===
 
@@ -330,6 +341,16 @@ Is a replacement for:
       async_wait:
         alias: blah
         retries: 100
+        delay: 5
+
+Another example with `script`:
+
+    - name: Async recoverable job with script
+      async_task:
+        script: sleep.sh 10
+        alias: blah
+        async: 60
+        retries: 10
         delay: 5
 
 Temporary files

--- a/example-playbooks/async_extra/action_plugins/async_task.py
+++ b/example-playbooks/async_extra/action_plugins/async_task.py
@@ -155,6 +155,9 @@ class ActionModule(ActionBase):
         running = self.find_running_task(alias, task_vars)
         if is_failed(running):
             result.update(running)
+            if is_finished(running):
+                result['warning'] = 'The job is finished and was not cleaned up properly. Please, delete job alias ' \
+                                    'manually to restart.'
             return result
 
         if running['started'] != 1:
@@ -189,6 +192,10 @@ class ActionModule(ActionBase):
                 delay=delay,
                 vars=task_vars
             ))
+
+            if is_failed(result):
+                result['warning'] = 'The job has failed and was not cleaned up properly. Please, delete job alias ' \
+                                    'manually to restart.'
         elif poll:
             raise AnsibleActionFail("poll is not supported yet")
 
@@ -388,3 +395,6 @@ class ActionModule(ActionBase):
 def is_failed(result):
     return 'failed' in result and result['failed']
 
+
+def is_finished(x):
+    return 'finished' in x and x['finished']

--- a/example-playbooks/async_extra/action_plugins/async_task.py
+++ b/example-playbooks/async_extra/action_plugins/async_task.py
@@ -94,6 +94,18 @@ started:
 
 class ActionModule(ActionBase):
 
+    _VALID_ARGS = frozenset((
+        # required
+        'alias', 'async',
+        # optional
+        'retries', 'delay', 'poll',
+        'cleanup',
+        # ansible.legacy.command
+        'shell', 'cmd', 'argv',
+        'chdir', 'executable', 'creates', 'removes', 'warn', 'stdin',
+        'stdin_add_newline', 'strip_empty_ends'
+    ))
+
     def run(self, tmp=None, task_vars=None):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
@@ -184,6 +196,14 @@ class ActionModule(ActionBase):
             # Shell module is implemented via command with a special arg
             task.args['_uses_shell'] = True
             task.args.pop('shell')
+        elif 'cmd' in task.args:
+            task.args['_raw_params'] = task.args['cmd']
+            # Shell module is implemented via command with a special arg
+            task.args['_uses_shell'] = False
+            task.args.pop('cmd')
+        elif 'argv' in task.args:
+            # Shell module is implemented via command with a special arg
+            task.args['_uses_shell'] = False
 
         allowed = ('_raw_params', '_uses_shell', 'argv', 'chdir', 'executable', 'creates', 'removes', 'warn', 'stdin',
                    'stdin_add_newline', 'strip_empty_ends')

--- a/example-playbooks/async_extra/async_task_cmd.yml
+++ b/example-playbooks/async_extra/async_task_cmd.yml
@@ -1,0 +1,11 @@
+#!/usr/sbin/ansible-playbook ./async_task_cmd.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Async command
+      async_task:
+        cmd: /usr/sbin/sleep 10
+        alias: blah
+        async: 1000
+        retries: 720
+        delay: 5

--- a/example-playbooks/async_extra/async_task_cmd_argv.yml
+++ b/example-playbooks/async_extra/async_task_cmd_argv.yml
@@ -1,0 +1,13 @@
+#!/usr/sbin/ansible-playbook ./async_task_cmd_argv.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Long running task
+      async_task:
+        argv:
+          - /usr/sbin/sleep
+          - 10
+        alias: blah
+        async: 1000
+        retries: 720
+        delay: 5

--- a/example-playbooks/async_extra/async_task_script.yml
+++ b/example-playbooks/async_extra/async_task_script.yml
@@ -1,0 +1,11 @@
+#!/usr/sbin/ansible-playbook ./async_status_id_recoverable.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+    - name: Long running task
+      async_task:
+        script: sleep.sh
+        alias: blah
+        async: 1000
+        retries: 720
+        delay: 5

--- a/example-playbooks/async_extra/async_task_script_fail.yml
+++ b/example-playbooks/async_extra/async_task_script_fail.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Async recoverable job with script
       async_task:
-        script: sleep.sh 10
+        script: sleep.sh
         alias: blah
         async: 60
         retries: 10

--- a/example-playbooks/async_extra/cmd.yml
+++ b/example-playbooks/async_extra/cmd.yml
@@ -1,0 +1,6 @@
+#!/usr/sbin/ansible-playbook ./async_task_cmd.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+      - ansible.builtin.command:
+          cmd: sleep 10

--- a/example-playbooks/async_extra/cmd_argv.yml
+++ b/example-playbooks/async_extra/cmd_argv.yml
@@ -1,0 +1,8 @@
+#!/usr/sbin/ansible-playbook ./async_task_cmd.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+      - ansible.builtin.command:
+          argv:
+            - sleep
+            - 10

--- a/example-playbooks/async_extra/install.sh
+++ b/example-playbooks/async_extra/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# https://docs.ansible.com/ansible/latest/dev_guide/developing_locally.html
+
+mkdir -p ~/.ansible/plugins/action
+mkdir -p ~/.ansible/plugins/modules
+
+cp ./library/* ~/.ansible/plugins/modules/
+cp ./action_plugins/* ~/.ansible/plugins/action/

--- a/example-playbooks/async_extra/script.yml
+++ b/example-playbooks/async_extra/script.yml
@@ -1,0 +1,8 @@
+#!/usr/sbin/ansible-playbook ./script.yml -vvvv
+---
+- hosts: localhost
+  tasks:
+      - ansible.builtin.script: ./sleep.sh 10
+      - ansible.builtin.script:
+          cmd: ./sleep.sh 10
+

--- a/example-playbooks/async_extra/sleep.sh
+++ b/example-playbooks/async_extra/sleep.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo '{"job": false}'
+
+if [ -z "$1" ]; then
+  echo "error: argument missing" > /dev/stderr
+  exit 1
+fi
+
+sleep "$1"
+
+echo '{"job": true}'

--- a/example-playbooks/run_cleanup/files/cleanup.sh
+++ b/example-playbooks/run_cleanup/files/cleanup.sh
@@ -1,27 +1,34 @@
 #!/bin/bash
 
-DIRS="`grep data_file_directories /etc/scylla/scylla.yaml`"
-RC=$?
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
 
-if [ $RC == 0 ]
-then
-DIR=$(grep -A1 data_file_directories /etc/scylla/scylla.yaml|grep -v 'data_file_directories:'|awk '{ print $NF }')
-else
 DIR="/var/lib/scylla/data"
+CONF="/etc/scylla/scylla.yaml"
+
+if [ -f "$CONF" ]; then
+    if grep -q data_file_directories "$CONF"; then
+        DIR=$(grep -A1 data_file_directories "$CONF" | grep -v 'data_file_directories:' | awk '{ print $NF }')
+    fi
 fi
 
-cd $DIR
+if [ ! -d "$DIR " ]; then
+    echo "error: $DIR does not exist"
+    exit 1
+fi
 
 echo "running on $HOSTNAME"
 
-echo "cleaning first detected data dir:"
-pwd
+cd "$DIR"
+echo "cleaning first detected data dir:"; pwd
 
-PATHS=$(du -m --max-depth=2 .|sort -k1h|awk -F"/" 'NF==3'|awk '{ print $NF}'|egrep -v '^./system/'\|'^./system_auth/'\|'^./system_distributed/'\|'^./system_traces/'\|'^./system_schema/')
+PATHS=$(du -m --max-depth=2 .|sort -k1h|awk -F"/" 'NF==3'|awk '{ print $NF}'|grep -E -v '^./system/'\|'^./system_auth/'\|'^./system_distributed/'\|'^./system_traces/'\|'^./system_schema/')
 
 for i in $PATHS; do
-    TB=$(echo $i|awk -F'/' '{ print $NF }'|awk -F'-' '{ print $1 }')
-    KS=$(echo $i|awk -F'/' '{ print $(NF - 1) }')
+    TB=$(echo "$i"|awk -F'/' '{ print $NF }'|awk -F'-' '{ print $1 }')
+    KS=$(echo "$i"|awk -F'/' '{ print $(NF - 1) }')
     echo "cleanup of $KS $TB"
-    nodetool cleanup $KS $TB
+    nodetool cleanup "$KS" "$TB"
 done

--- a/example-playbooks/run_cleanup/run.sh
+++ b/example-playbooks/run_cleanup/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+# set -o nounset
+# set -o xtrace
+
+# Set magic variables for current file & dir
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXTRA="$DIR/async_extra"
+
+if [ -z "$1" ]; then
+  echo "error: limit is required"
+  exit 1
+fi
+
+ANSIBLE_ACTION_PLUGINS=$EXTRA/action_plugins ansible-playbook ./run_cleanup.yml -vvvv -M $EXTRA/library -l $1

--- a/example-playbooks/run_cleanup/run_cleanup.yml
+++ b/example-playbooks/run_cleanup/run_cleanup.yml
@@ -10,8 +10,14 @@
         msg: "You must use -l or --limit. To cleanup the entire cluster, use -l 'all'"
       when: ansible_limit is not defined
 
+    # 2592000 a month of seconds, retry every 1 minute
     - name: Run cleanup
-      script:  files/cleanup.sh
+      async_task:
+        script:  files/cleanup.sh
+        alias: scylla_cleanup
+        async: 2592000
+        retries: 43200
+        delay: 60
       register: cleanup_output
 
     - name: Cleanup logs


### PR DESCRIPTION
- script support
- cmd support
- failed jobs warning
- run cleanup async

magic:

```
    - name: Run cleanup
      async_task:
        script:  files/cleanup.sh
        alias: scylla_cleanup
        async: 2592000
        retries: 43200
        delay: 60
      register: cleanup_output
```

Run
===

    $ ./run.sh localhost

or

    $ ANSIBLE_ACTION_PLUGINS=../async_extra/action_plugins ansible-playbook ./run_cleanup.yml -vvvv -l localhost -M ../async_extra/library

Note
===

it is critical to rework `./files/cleanup.sh` to exit with a non-zero error code if it actually fails. currently, it is not. but that's outside of the pr series.