### PR TITLE
Set host for "Wait for CQL port"

### DIFF
--- a/example-playbooks/restore_scylla_manager_backup/restore.yaml
+++ b/example-playbooks/restore_scylla_manager_backup/restore.yaml
@@ -66,6 +66,7 @@
     - name: Wait for CQL port
       wait_for:
         port: 9042
+        host: "{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}"
 
     - name: Stop Scylla service
       service:
@@ -102,6 +103,7 @@
     - name: Wait for CQL port
       wait_for:
         port: 9042
+        host: "{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}"
 
     - name: Resore seeds list
       lineinfile:


### PR DESCRIPTION
Explicitly set host for "Wait for CQL port" in restore_scylla_manager_backup/restore.yaml

Without this, the "Wait for CQL port" step timed out every time on gcs. (machine build from machine image)