### PR TITLE
Install correct version of openjdk on Debian

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -19,8 +19,8 @@ jobs:
         molecule_distro:
           #- centos7
           - centos8
-          #- debian9
-          #- debian10
+          - debian9
+          - debian10
           #- fedora
           #- ubuntu1604
           - ubuntu1804

--- a/ansible-scylla-loader/tasks/Debian.yml
+++ b/ansible-scylla-loader/tasks/Debian.yml
@@ -53,9 +53,21 @@
   when: scylla_dependencies is defined and (scylla_dependencies|length > 0)
   become: true
 
+- name: Set Java facts for Debian 8 and 9
+  set_fact:
+    java_package_name: "openjdk-8-jre-headless"
+    java_path: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+  when: ansible_distribution_major_version|int < 10
+
+- name: Set Java facts for Debian 10 and above
+  set_fact:
+    java_package_name: "openjdk-11-jre-headless"
+    java_path: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+  when: ansible_distribution_major_version|int > 9
+
 - name: Install Java
   apt:
-    name: openjdk-8-jre-headless
+    name: "{{ java_package_name }}"
     state: present
     force_apt_get: yes
   become: true
@@ -63,7 +75,7 @@
 - name: Correct java version selected
   alternatives:
     name: java
-    path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+    path: "{{ java_path }}"
   become: true
 
 - name: install scylla-tools-core|scylla-enterprise-tools-core

--- a/ansible-scylla-node/meta/main.yml
+++ b/ansible-scylla-node/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
     versions:
     - 8
     - 9
+    - 10
   - name: Ubuntu
     versions:
     - 20.04

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -49,14 +49,14 @@
 
   - name: Install Java
     apt:
-      name: openjdk-8-jre-headless
+      name: openjdk-11-jre-headless
       state: present
       force_apt_get: yes
 
   - name: Correct java version selected
     alternatives:
       name: java
-      path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      path: /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
   - name: Install latest OSS Scylla
     apt:

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -47,16 +47,30 @@
       force_apt_get: yes
     when: scylla_dependencies is defined and (scylla_dependencies|length > 0)
 
-  - name: Install Java
-    apt:
-      name: openjdk-11-jre-headless
-      state: present
-      force_apt_get: yes
+- name: Set Java facts for Debian 8 and 9
+  set_fact:
+    java_package_name: "openjdk-8-jre-headless"
+    java_path: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+  when: ansible_distribution_major_version|int < 10
 
-  - name: Correct java version selected
-    alternatives:
-      name: java
-      path: /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+- name: Set Java facts for Debian 10 and above
+  set_fact:
+    java_package_name: "openjdk-11-jre-headless"
+    java_path: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+  when: ansible_distribution_major_version|int > 9
+
+- name: Install Java
+  apt:
+    name: "{{ java_package_name }}"
+    state: present
+    force_apt_get: yes
+  become: true
+
+- name: Correct java version selected
+  alternatives:
+    name: java
+    path: "{{ java_path }}"
+  become: true
 
   - name: Install latest OSS Scylla
     apt:


### PR DESCRIPTION
On Debian 10 (current stable) openjdk-8 isn't available, openjdk-11 should be installed instead.