### PR TITLE
[FEAT] add support for custom data and log path in config template

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -92,6 +92,13 @@ scylla_io_probe: True
 
 io_conf: 'SEASTAR_IO="--io-properties-file /etc/scylla.d/io_properties.yaml"'
 
+# Data file directory
+data_file_directories:
+    - /var/lib/scylla/data
+
+# commit log directory
+commitlog_directory: "/var/lib/scylla/commitlog"
+
 # Seeds node list
 scylla_seeds:
   - "{{ groups['scylla'][0] }}"

--- a/ansible-scylla-node/templates/scylla.yaml.j2
+++ b/ansible-scylla-node/templates/scylla.yaml.j2
@@ -4,9 +4,11 @@
 cluster_name: "{{ scylla_cluster_name }}"
 
 data_file_directories:
-    - /var/lib/scylla/data
+{%- for path in data_file_directories %}
+    - {{ path }}
+{%- endfor %}
 
-commitlog_directory: /var/lib/scylla/commitlog
+commitlog_directory: "{{ commitlog_directory }}"
 
 {% if scylla_authentication is defined and scylla_authentication|bool %}
 authenticator: PasswordAuthenticator


### PR DESCRIPTION
Having in mind previously configured raids it would be nice to be able to set the path for data and logs during the role application. 

This intends to do this with some variables that can be set to the user choice.