### PR TITLE
scylla node role: retry for check API access at least 90x

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -255,7 +255,7 @@
         method: GET
       register: _result
       until: _result.status == 200
-      retries: 30
+      retries: 90
       delay: 1
 
     - name: generate monitoring configuration


### PR DESCRIPTION
fixes #103