### PR TITLE
ansible-scylla-node: resolve another composite variable

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -225,19 +225,24 @@
       set_fact:
         listen_address: "{{ scylla_listen_address }}"
 
+    # The same relates to the below
+    - name: Resolve Scylla NIC IPv4 address
+      set_fact:
+        scylla_nic_ipv4: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
+
     # Start all seeders together since we don't know which one is the "first" - so let them figure it by themselves
     - name: start scylla on seeders
       service:
         name: scylla-server
         state: started
       become: true
-      when: vars['ansible_'~scylla_nic].ipv4.address in scylla_seeds or inventory_hostname in scylla_seeds
+      when: scylla_nic_ipv4 in scylla_seeds or inventory_hostname in scylla_seeds
 
     - name: Wait for CQL port on seeders
       wait_for:
         port: 9042
         host: "{{ listen_address }}"
-      when: vars['ansible_'~scylla_nic].ipv4.address in scylla_seeds or inventory_hostname in scylla_seeds
+      when: scylla_nic_ipv4 in scylla_seeds or inventory_hostname in scylla_seeds
 
     - name: Start scylla non-seeds nodes serially
       run_once: true
@@ -245,7 +250,7 @@
       loop: "{{ groups['scylla'] }}"
       when:
         - item not in scylla_seeds
-        - hostvars[item]['ansible_'~scylla_nic]['ipv4']['address'] not in scylla_seeds
+        - hostvars[item]['scylla_nic_ipv4'] not in scylla_seeds
 
     - name: wait for the API port to come up on all nodes
       wait_for:


### PR DESCRIPTION
Resolve vars['ansible_'~scylla_nic].ipv4.address into a fact
in order to be able to use it in a loop.

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>