### PR TITLE
Add get scylla version playbook

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -152,7 +152,8 @@ scylla_dependencies:
 
 # Specify a Scylla version here (should be available in repo)
 # ex: scylla_version: 2019.1.9 or 3.2.1
-scylla_version: latest
+# Default is intentionally invalid version - it MUST be overridden
+scylla_version: '0.0.0'
 
 # Options are oss|enterprise
 #scylla_edition: oss

--- a/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
@@ -42,6 +42,7 @@ provisioner:
         scylla_deb_repos:
           - "http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list"
         scylla_edition: "enterprise"
+        scylla_version: "latest"
         scylla_io_probe: false
         io_properties:
           disks:

--- a/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
@@ -42,6 +42,7 @@ provisioner:
         scylla_deb_repos:
           - "http://downloads.scylladb.com/deb/ubuntu/scylla-4.4-focal.list"
         scylla_edition: "oss"
+        scylla_version: "latest"
         scylla_io_probe: false
         io_properties:
           disks:

--- a/extra-playbooks/get_scylla_version.yml
+++ b/extra-playbooks/get_scylla_version.yml
@@ -1,0 +1,14 @@
+---
+
+- hosts: scylla
+  gather_facts: no
+  tasks:
+    - name: Get scylla version from the first node
+      shell: |
+        scylla --version
+      run_once: true
+      register: _scylla_version
+
+    - name: Show the version
+      debug:
+        var: _scylla_version.stdout


### PR DESCRIPTION
Scylla Role supports a 'latest' label as a Scylla Version (`scylla_version` parameter) however when we persist the Role state we should avoid storing `scylla_version: latest` in order to avoid unintentional SW upgrades next time we run a Role.

We should store the actual Scylla version instead.

This PR introduces a helper playbook that allows fetching a Scylla version and also "breaks" the default the way that would require to always explicitly provide a `scylla_version` parameter when a Role is executed.