### PR TITLE
Only update apt cache, don't upgrade all packages for Ubuntu

### DIFF
--- a/ansible-scylla-loader/tasks/Debian.yml
+++ b/ansible-scylla-loader/tasks/Debian.yml
@@ -25,11 +25,8 @@
     when: scylla_repo_keyfile_urls is defined and (scylla_repo_keyfile_urls|length > 0)
   become: true
 
-- name: Upgrade all packages to the latest version
+- name: Update apt cache
   apt:
-    name: "*"
-    state: latest
-    force_apt_get: yes
     update_cache: yes
   become: true
 

--- a/ansible-scylla-monitoring/tasks/Debian.yml
+++ b/ansible-scylla-monitoring/tasks/Debian.yml
@@ -1,9 +1,6 @@
 ---
-- name: Upgrade all packages to the latest version
+- name: Update apt cache
   apt:
-    name: "*"
-    state: latest
-    force_apt_get: yes
     update_cache: yes
   become: true
 
@@ -45,11 +42,8 @@
     shell: |
       sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
 
-  - name: Upgrade all packages to the latest version (again)
+  - name: Update apt cache
     apt:
-      name: "*"
-      state: latest
-      force_apt_get: yes
       update_cache: yes
 
   - name: install docker


### PR DESCRIPTION
For monitoring and loader roles