### PR TITLE
Remove output to logs

### DIFF
--- a/ansible-scylla-manager/tasks/add-clusters.yml
+++ b/ansible-scylla-manager/tasks/add-clusters.yml
@@ -22,3 +22,4 @@
       --password {{ item.password }} \
       {% endif %}
   when: cluster_already_added is not defined or cluster_already_added.stdout != "present"
+  no_log: true

--- a/ansible-scylla-manager/tasks/main.yml
+++ b/ansible-scylla-manager/tasks/main.yml
@@ -59,6 +59,7 @@
 - name: add Scylla clusters
   include_tasks: add-clusters.yml
   loop: "{{ scylla_clusters }}"
+  no_log: true
 
 
 


### PR DESCRIPTION
This task seems to dump username / password / auth token to the outputted logs. Adding a no_log: true will still show the task running, but remove a great deal of the output.

Tested in a local copy