### PR TITLE
Node Role - Forbid Scylla upgrade when not explicitly requested

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -5,6 +5,12 @@
 # UPGRADE
 # ==============================
 
+# Skips role upgrade check. Useful if the role failed in the middle of an installation.
+# Values:
+# [default] false: Fail when Scylla is installed and the upgrade_version == False
+# true: When upgrade_version == False, re-run the install process 
+skip_upgrade_check: false
+
 # Upgrades Scylla version if a previous installation is detected
 # Values:
 #  [default] false: don't check for upgrades

--- a/ansible-scylla-node/tasks/main.yml
+++ b/ansible-scylla-node/tasks/main.yml
@@ -13,8 +13,9 @@
     msg: >
       Detected an existing Scylla installation.
       Should you want to upgrade, set `upgrade_version' to True.
+      If you are recovering from a failed role run, set `skip_upgrade_check' to True.
   when: >
-      not upgrade_version and
+      not upgrade_version and not skip_upgrade_check and
       ( 'scylla-server' in ansible_facts.packages or
         'scylla-enterprise-server' in ansible_facts.packages )
 

--- a/ansible-scylla-node/tasks/main.yml
+++ b/ansible-scylla-node/tasks/main.yml
@@ -8,6 +8,16 @@
   package_facts:
     manager: auto
 
+- name: Check whether Scylla is already installed
+  fail:
+    msg: >
+      Detected an existing Scylla installation.
+      Should you want to upgrade, set `upgrade_version' to True.
+  when: >
+      not upgrade_version and
+      ( 'scylla-server' in ansible_facts.packages or
+        'scylla-enterprise-server' in ansible_facts.packages )
+
 # Upgrade
 - name: Upgrade Scylla
   include_tasks: upgrade/main.yml


### PR DESCRIPTION
This series introduces an early check to determine whether Scylla is already installed on the target system.
It provides a mechanism to prevent incorrectly (and dangerously) upgrading a system which may be already part of a running cluster.

In such scenarios, we now require `upgrade_version: True`, which delegates ALL upgrade logic to its relevant upgrade section in the role.

To prevent a "chicken and egg" situation when we fail in the middle of a role execution AND after Scylla has been installed, we introduce the `skip_upgrade_check` option as a failsafe mechanism, which - obviously - defaults to false.

Tests ran:
1. Fail role execution after an install of Scylla in a single node cluster (this is - in fact, what led to https://github.com/scylladb/scylla-ansible-roles/issues/139 ;-)
2. Try to execute role again, we see a failure complaining that Scylla is already installed.
3. Add the `skip_upgrade_check: True` option, which allows us to get through and proceed with the installation/configuration process
4. **Revert** the `skip_upgrade_check: True` option, we see a failure complaining that Scylla is already installed.
5. Bump Scylla minor version and add the `upgrade_version: True` && `upgrade_major: False` options, upgrade completes.

Fixes #132 