### PR TITLE
OpenJDK - Fix inconsistencies

### DIFF
--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -49,14 +49,14 @@
 
   - name: Install Java
     apt:
-      name: openjdk-8-jre-headless
+      name: openjdk-11-jre-headless
       state: present
       force_apt_get: yes
 
   - name: Correct java version selected
     alternatives:
       name: java
-      path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      path: /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
   - name: "Going to install {{ scylla_version }}"
     set_fact:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -258,9 +258,24 @@
         host: "{{ scylla_api_address }}"
         timeout: 300
 
+    - name: Determine if Scylla release is prone to CASSANDRA-17581
+      shell:
+        cmd: nodetool status
+      register: nodetool
+      ignore_errors: True
+
+    - name: Configure JAVA_TOOL_OPTIONS in /etc/environment
+      lineinfile:
+        path: /etc/environment
+        regexp: '^JAVA_TOOL_OPTIONS='
+        line: 'JAVA_TOOL_OPTIONS="-Dcom.sun.jndi.rmiURLParsing=legacy"'
+        state: present
+      when:
+        - '"URISyntaxException" in nodetool.stderr'
+
     - name: wait for the cluster to become healthy
       shell: |
-        nodetool status|grep -E '^UN|^UJ|^DN'|wc -l
+        nodetool -Dcom.sun.jndi.rmiURLParsing=legacy status|grep -E '^UN|^UJ|^DN'|wc -l
       register: node_count
       until: node_count.stdout|int == ansible_play_batch|length
       retries: 300


### PR DESCRIPTION
This series addresses two OpenJDK related inconsistencies across Ubuntu/Debian/CentOS:

As Debian 10 onward no longer ship with OpenJDK 8, we bump its version to OpenJDK 11. Similarly, we also let Ubuntu make use of that as it no longer ships updates to OpenJDK 8 (therefore, it should be eventually be removed in future releases). CentOS - on the other hand - still ships updates to OpenJDK 8 (via EPEL) and we let the default installer pick its latest release as usual.

However, installing a recent OpenJDK version in either distribution unveils https://github.com/scylladb/scylla/issues/10442, which needs to be treated accordingly. This is handled in the second commit in this series.

Fixes #142 