### PR TITLE
Node Role - upgrade_major should default to False

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -13,9 +13,9 @@ upgrade_version: false
 
 # Defines if the upgrade is 'major' or 'minor' (patch)
 # Values:
-#  [default] true: 'major' upgrade
-#  false: 'minor' upgrade
-upgrade_major: true
+#  [default] false: 'minor' upgrade
+#  true: 'major' upgrade
+upgrade_major: false
 
 # Defines if the upgrade process should rollback on failure
 # Values:


### PR DESCRIPTION
It makes no sense for `upgrade_major` to be set to `True`. Major upgrades must **always** be explicitly requested, whereas minor ones should always have the precedence.