### PR TITLE
scylla-ansible-monitoring: persist alertmanager data by default.

### DIFF
--- a/ansible-scylla-monitoring/defaults/main.yml
+++ b/ansible-scylla-monitoring/defaults/main.yml
@@ -22,6 +22,7 @@ scylla_monitoring_archive_url: 'https://github.com/scylladb/scylla-monitoring/ar
 scylla_monitoring_deploy_path: /opt/scylla-monitoring
 scylla_monitoring_data_path: "{{ scylla_monitoring_deploy_path }}/data"
 scylla_monitoring_config_path:  "{{ scylla_monitoring_deploy_path }}/config"
+scylla_monitoring_alertdata_path: "{{ scylla_monitoring_deploy_path }}/alertdata"
 
 # List of monitoring dashboards to enable
 scylla_monitoring_dashboards_versions:

--- a/ansible-scylla-monitoring/tasks/docker.yml
+++ b/ansible-scylla-monitoring/tasks/docker.yml
@@ -111,6 +111,7 @@
       cd {{ base_dir }}
       ./start-all.sh \
         -d {{ scylla_monitoring_data_path }} \
+        -f {{ scylla_monitoring_data_path }} \
         -v {{ scylla_monitoring_dashboards_versions|join(',') }} \
         -s {{ scylla_monitoring_config_path }}/scylla_servers.yml \
         -N {{ scylla_monitoring_config_path }}/scylla_manager_servers.yml \


### PR DESCRIPTION
Uses `scylla_monitoring_alertdata_path` variable, passed on to `start-all.sh`.
Deafults to "{{ scylla_monitoring_deploy_path }}/alertdata".

Fixes #124