### PR TITLE
scylla-ansible-monitorin: fix directory used for alert data.

### DIFF
--- a/ansible-scylla-monitoring/tasks/common.yml
+++ b/ansible-scylla-monitoring/tasks/common.yml
@@ -26,6 +26,15 @@
     owner: "{{ ansible_user_id }}"
   become: true
 
+- name: create the alert data directory
+  file:
+    path: "{{ scylla_monitoring_alertdata_path }}"
+    state: directory
+    mode: '1777'
+    recurse: yes
+    owner: "{{ ansible_user_id }}"
+  become: true
+
 - name: download the monitoring archive
   get_url:
     url: "{{ scylla_monitoring_archive_url }}"

--- a/ansible-scylla-monitoring/tasks/docker.yml
+++ b/ansible-scylla-monitoring/tasks/docker.yml
@@ -111,7 +111,7 @@
       cd {{ base_dir }}
       ./start-all.sh \
         -d {{ scylla_monitoring_data_path }} \
-        -f {{ scylla_monitoring_data_path }} \
+        -f {{ scylla_monitoring_alertdata_path }} \
         -v {{ scylla_monitoring_dashboards_versions|join(',') }} \
         -s {{ scylla_monitoring_config_path }}/scylla_servers.yml \
         -N {{ scylla_monitoring_config_path }}/scylla_manager_servers.yml \


### PR DESCRIPTION
docker.yml used scylla_monitoring_data_path instead of
scylla_monitoring_data_path due to a typo.

Also, explicitly create the abovementioned directory.