### PR TITLE
Node role - Correctly generate CA certificate and update references

### DIFF
--- a/ansible-scylla-node/tasks/ssl.yml
+++ b/ansible-scylla-node/tasks/ssl.yml
@@ -11,18 +11,23 @@
         path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
 
     - name: Generate an OpenSSL Certificate Signing Request for the CA
-      openssl_csr:
-        path: "./ssl/ca/{{ scylla_cluster_name }}-ca.csr"
+      community.crypto.openssl_csr_pipe:
         privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
         common_name: "{{ scylla_cluster_name }}.internal"
+        use_common_name_for_san: false  # since we do not specify SANs, don't use CN as a SAN
+        basic_constraints:
+          - 'CA:TRUE'
+        basic_constraints_critical: yes
+        key_usage:
+          - keyCertSign
+        key_usage_critical: true
+      register: ca_csr
 
     - name: Generate a Self Signed OpenSSL certificate for the CA
-      openssl_certificate:
+      community.crypto.x509_certificate:
         path: "./ssl/ca/{{scylla_cluster_name }}-ca.crt"
         privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
-        csr_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.csr"
-#        issuer:
-#          commonName: "{{ scylla_cluster_name }}.internal"
+        csr_content: "{{ ca_csr.csr }}"
         provider: selfsigned
   delegate_to: localhost
   run_once: true

--- a/ansible-scylla-node/templates/cqlshrc.j2
+++ b/ansible-scylla-node/templates/cqlshrc.j2
@@ -5,13 +5,11 @@ password = cassandra
 [connection]
 hostname = {{ groups['scylla'][0] }}
 port = 9142
+factory = cqlshlib.ssl.ssl_transport_factory
 
 [ssl]
-certfile = ./ssl/{{ groups['scylla'][0] }}/{{ groups['scylla'][0] }}.crt
-validate = false ;; Optional, true by default. See the paragraph below.
+version=TLSv1_2
+certfile = {{ scylla_ssl.cert_path }}/{{ scylla_cluster_name }}-ca.crt
+validate = true ;; Optional, true by default. See the paragraph below.
 
 [certfiles] ;; Optional section, overrides the default certfile in the [ssl] section.
-{% for host in groups['scylla'] %}
-{{ host }} = ./ssl/{{ host }}/{{ host }}.crt
-{% endfor %}
-


### PR DESCRIPTION
Our previous implementation of ssl.yml incorrectly generated a self-signed certificate mistakenly named as a "CA".

As it turns out, a CA certificate needs to have some specific characteristics in order to be considered a proper Certificate Authority.
Due to that, the CA certificate couldn't be used by clients to properly authenticate against the nodes, in such a way that clients were required to skip TLS verification in order to connect.

This mini-series corrects that situation and also updates the generated `cqlshrc` template to properly use the CA certificate created.

Fixes #161 
Closes #161 