### PR TITLE
example-playbooks: Implements batch size

### DIFF
--- a/example-playbooks/run_cleanup/run_cleanup.yml
+++ b/example-playbooks/run_cleanup/run_cleanup.yml
@@ -3,7 +3,7 @@
 - name: Run cleanup
   hosts: scylla
   gather_facts: false
-  serial: 1
+  serial: "{{ cleanup_batch_size |default(1) }}"
   tasks:
     - name: checking limit arg
       fail:


### PR DESCRIPTION
This change allows the playbook to be run on multiple nodes at the same time

Ref: #169

Signed-off-by: Eduardo Benzecri <eduardo.benzecri@scylladb.com>