### PR TITLE
rolling_restart.yml: wait for a CQL port to become operational before…

### DIFF
--- a/example-playbooks/rolling_ops/rolling_restart.yml
+++ b/example-playbooks/rolling_ops/rolling_restart.yml
@@ -42,6 +42,12 @@
         name: scylla-server
         state: started
 
+    - name: Wait for CQL port on {{ listen_address.stdout }}
+      wait_for:
+        port: 9042
+        host: "{{ listen_address.stdout }}"
+        timeout: 300
+
     - name: wait for the cluster to become healthy
       shell: |
         nodetool status|grep "{{ listen_address.stdout }}" | grep '^UN'


### PR DESCRIPTION
… continuing

It's not enough to wait for a gossip state (UN in the 'nodetool status' output). We need to wait for a scylla to become fully operational and this is when both a gossip state is UN and scylla listens to all relevant ports. And and CQL protocol is initialized the last (naturally).

So, let's wait for a CQL before checking the gossip state.

Fixes #26

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>