### PR TITLE
scylla_node: remove 'enable_sstables_mc_format: true'

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -197,7 +197,6 @@ scylla_api_port: '10000'
 scylla_yaml_params:
   authorizer: CassandraAuthorizer
   authenticator: PasswordAuthenticator
-  enable_sstables_mc_format: true
   internode_compression: all
 
 # SSL configuration for Scylla nodes:

--- a/example-playbooks/replace_node/README.md
+++ b/example-playbooks/replace_node/README.md
@@ -31,7 +31,6 @@ This playbook will run the replace dead node procedure.
 scylla_yaml_params:
   authorizer: CassandraAuthorizer
   authenticator: PasswordAuthenticator
-  enable_sstables_mc_format: true
   internode_compression: all
   #Add this line:
   replace_address_first_boot: "{{ replaced_node }}"


### PR DESCRIPTION
'enable_sstables_mc_format:true' is a default since Scylla Ent 2020.1.0. No need to specify it explicitly any more.

Fixes #85

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>