### PR TITLE
scylla_node: don't ignore errors when setting up a raid

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -32,7 +32,6 @@
         scylla_raid_setup --disks "{{ scylla_raid_setup | join(',') }}" --update-fstab
       become: true
       when: scylla_raid_setup is defined and scylla_raid_setup|length > 0 and scylla_raid_setup|length != present_raid_disks.stdout|int
-      ignore_errors: true
 
 - name: IO settings probe
   block:


### PR DESCRIPTION
We should never ignore errors in general and when setting the RAID up in particular.

If RAID exists, and it doesn't correspond to the configuration required - this requires an Operator intervention.

Fixes #152

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>