### PR TITLE
ansible-scylla-node: Allow user to provide their own certificates

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -208,17 +208,21 @@ scylla_yaml_params:
   internode_compression: all
 
 # SSL configuration for Scylla nodes:
+# localhost_cert_path is the path where the certificates will be stored in the localhost before they're coppied to the nodes. If not set,
+# the playbook will consider it to be the same path where the inventory is located.
+# cert_path is the path where the certificates will be placed in the scylla nodes.
 # If no certificates are present, this playbook will generate a selfsigned CA and node certificates locally and push them out to all the nodes.
-# WARNING: if a local ./ssl/ directory is not present and populated by existing certificates for all nodes, it will be generated
+# WARNING: if a local ${localhost_cert_path}/ssl/ directory is not present and populated by existing certificates for all nodes, it will be generated
 # and certificates on the nodes can get overwritten with new certificates.
 # To use existing certificates:
-# 1. To use your own CA, place it in ./ssl/ca/{{ scylla_cluster_name }}-ca.crt and its respective key in ./ssl/ca/{{ scylla_cluster_name }}-ca.pem
-# and derived per-node certificates will be generated from it, if they are not present.
-# 2. To use your own node certificates, create a directory per hostname (same as in the inventory) in ./ssl/{{ hostname }}
+# 1. To use your own CA, place it in ${localhost_cert_path}/ssl/ca/{{ scylla_cluster_name }}-ca.crt and its respective key in
+# ${localhost_cert_path}/ssl/ca/{{ scylla_cluster_name }}-ca.pem and derived per-node certificates will be generated from it, if they are not present.
+# 2. To use your own node certificates, create a directory per hostname (same as in the inventory) in ${localhost_cert_path}/ssl/{{ hostname }}
 # and place the .pem and .crt files as {{ hostname }}.pem and {{ hostname }}.crt respectively and then place the CA you used to sign the certificates in
-# ./ssl/ca/{{ scylla_cluster_name }}-ca.crt and its respective key in ./ssl/ca/{{ scylla_cluster_name }}-ca.pem.
+# ${localhost_cert_path}/ssl/ca/{{ scylla_cluster_name }}-ca.crt and its respective key in ${localhost_cert_path}/ssl/ca/{{ scylla_cluster_name }}-ca.pem.
 # To skip this configuration entirely, set enabled: false for both options or comment out the scylla_ssl variable.
 scylla_ssl:
+  # localhost_cert_path: path/to/certificates
   cert_path: /etc/scylla
   internode:
     enabled: true

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -208,15 +208,15 @@ scylla_yaml_params:
   internode_compression: all
 
 # SSL configuration for Scylla nodes:
-# If no certificates are present will generate a selfsigned CA and node certificates locally and push them out to all the nodes.
-# WARNING: if a local ./ssl/ directory is not present and populated by existing certificates, it will be generated
-# and certificates on the nodes can ge overwritten with new certificates.
+# If no certificates are present, this playbook will generate a selfsigned CA and node certificates locally and push them out to all the nodes.
+# WARNING: if a local ./ssl/ directory is not present and populated by existing certificates for all nodes, it will be generated
+# and certificates on the nodes can get overwritten with new certificates.
 # To use existing certificates:
-# 1. To use your own CA, place it in ./ssl/ca/{{ scylla_cluster_name }}-ca.pem and derived per-node certificates wll
-# be generated from it, if they are not present
+# 1. To use your own CA, place it in ./ssl/ca/{{ scylla_cluster_name }}-ca.crt and its respective key in ./ssl/ca/{{ scylla_cluster_name }}-ca.pem
+# and derived per-node certificates will be generated from it, if they are not present.
 # 2. To use your own node certificates, create a directory per hostname (same as in the inventory) in ./ssl/{{ hostname }}
-# and place the .pem file as {{ hostname }}.pem
-# The playbook will use the CA certificate to generate a signed host certificate for the .pem file and push them into the nodes
+# and place the .pem and .crt files as {{ hostname }}.pem and {{ hostname }}.crt respectively and then place the CA you used to sign the certificates in
+# ./ssl/ca/{{ scylla_cluster_name }}-ca.crt and its respective key in ./ssl/ca/{{ scylla_cluster_name }}-ca.pem.
 # To skip this configuration entirely, set enabled: false for both options or comment out the scylla_ssl variable.
 scylla_ssl:
   cert_path: /etc/scylla

--- a/ansible-scylla-node/tasks/ssl.yml
+++ b/ansible-scylla-node/tasks/ssl.yml
@@ -1,5 +1,49 @@
 ---
-- name: generate a self-signed CA and use it for node certs
+- name: For every node, check if crt file exists
+  stat:
+    path: "./ssl/{{ hostvars[item]['inventory_hostname'] }}/{{ hostvars[item]['inventory_hostname'] }}.crt"
+  register: _node_crt
+  loop: "{{ groups['scylla'] }}"
+  delegate_to: localhost
+  when: _node_crt is not defined or _node_crt.stat.exists == True
+  run_once: true
+
+- name: For every node, check if key file exists
+  stat:
+    path: "./ssl/{{ hostvars[item]['inventory_hostname'] }}/{{ hostvars[item]['inventory_hostname'] }}.pem"
+  register: _node_key
+  loop: "{{ groups['scylla'] }}"
+  delegate_to: localhost
+  when: _node_key is not defined or _node_key.stat.exists == True
+  run_once: true
+
+- name: Set existence of crt and key as a single fact
+  set_fact:
+    _crt_and_key_exist: "{{ item.stat.exists }}"
+  loop: "{{ _node_crt.results + _node_key.results }}"
+  when: _crt_and_key_exist is not defined or _crt_and_key_exist == True
+  run_once: true
+
+- name: Check if CA exists
+  block:
+    - name: Check if CA crt file exists
+      stat:
+        path: "./ssl/ca/{{ scylla_cluster_name }}-ca.crt"
+      register: _ca_crt
+    - name: Check if CA key file exists
+      stat:
+        path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
+      register: _ca_key
+    - set_fact:
+        _ca_crt_and_key_exist: "{{ _ca_crt.stat.exists|bool and _ca_key.stat.exists|bool }}"
+  delegate_to: localhost
+  run_once: true
+
+- fail:
+    msg: "If you want to use your own node certificates you also have to provide a CA"
+  when: _crt_and_key_exist and not _ca_crt_and_key_exist
+
+- name: If crt and keys were not provided for all nodes and no CA was provided, generate a self-signed CA
   block:
     - name: Create dir for the CA
       file:
@@ -29,10 +73,11 @@
         privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
         csr_content: "{{ ca_csr.csr }}"
         provider: selfsigned
+  when: _crt_and_key_exist == False and _ca_crt_and_key_exist == False
   delegate_to: localhost
   run_once: true
 
-- name: Generate keys signed by the local CA and push them to the nodes
+- name: Generate keys signed by the local CA
   block:
     - name: Create a directory for the key
       file:
@@ -60,19 +105,20 @@
         ownca_privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
         provider: ownca
       delegate_to: localhost
+  when: _crt_and_key_exist == False
 
-    - name: Copy the certificates into their proper locations
-      copy:
-        src: "{{ item }}"
-        dest: "{{ scylla_ssl.cert_path }}/{{ item | basename }}"
-        owner: root
-        group: root
-        mode: '0644'
-      become: true
-      loop:
-        - "./ssl/ca/{{ scylla_cluster_name }}-ca.crt"
-        - "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.crt"
-        - "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
+- name: Copy the certificates into their proper locations
+  copy:
+    src: "{{ item }}"
+    dest: "{{ scylla_ssl.cert_path }}/{{ item | basename }}"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  loop:
+    - "./ssl/ca/{{ scylla_cluster_name }}-ca.crt"
+    - "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.crt"
+    - "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
 
 - name: Generate cqlshrc
   template:

--- a/ansible-scylla-node/tasks/ssl.yml
+++ b/ansible-scylla-node/tasks/ssl.yml
@@ -1,7 +1,10 @@
 ---
+- set_fact:
+    _localhost_cert_path: "{{ scylla_ssl.localhost_cert_path | default(inventory_dir) }}"
+
 - name: For every node, check if crt file exists
   stat:
-    path: "./ssl/{{ hostvars[item]['inventory_hostname'] }}/{{ hostvars[item]['inventory_hostname'] }}.crt"
+    path: "{{ _localhost_cert_path }}/ssl/{{ hostvars[item]['inventory_hostname'] }}/{{ hostvars[item]['inventory_hostname'] }}.crt"
   register: _node_crt
   loop: "{{ groups['scylla'] }}"
   delegate_to: localhost
@@ -10,7 +13,7 @@
 
 - name: For every node, check if key file exists
   stat:
-    path: "./ssl/{{ hostvars[item]['inventory_hostname'] }}/{{ hostvars[item]['inventory_hostname'] }}.pem"
+    path: "{{ _localhost_cert_path }}/ssl/{{ hostvars[item]['inventory_hostname'] }}/{{ hostvars[item]['inventory_hostname'] }}.pem"
   register: _node_key
   loop: "{{ groups['scylla'] }}"
   delegate_to: localhost
@@ -28,11 +31,11 @@
   block:
     - name: Check if CA crt file exists
       stat:
-        path: "./ssl/ca/{{ scylla_cluster_name }}-ca.crt"
+        path: "{{ _localhost_cert_path }}/ssl/ca/{{ scylla_cluster_name }}-ca.crt"
       register: _ca_crt
     - name: Check if CA key file exists
       stat:
-        path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
+        path: "{{ _localhost_cert_path }}/ssl/ca/{{ scylla_cluster_name }}-ca.pem"
       register: _ca_key
     - set_fact:
         _ca_crt_and_key_exist: "{{ _ca_crt.stat.exists|bool and _ca_key.stat.exists|bool }}"
@@ -47,16 +50,16 @@
   block:
     - name: Create dir for the CA
       file:
-        path: ./ssl/ca
+        path: "{{ _localhost_cert_path }}/ssl/ca"
         state: directory
 
     - name: Generate an OpenSSL private key for the CA.
       openssl_privatekey:
-        path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
+        path: "{{ _localhost_cert_path }}/ssl/ca/{{ scylla_cluster_name }}-ca.pem"
 
     - name: Generate an OpenSSL Certificate Signing Request for the CA
       community.crypto.openssl_csr_pipe:
-        privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
+        privatekey_path: "{{ _localhost_cert_path }}/ssl/ca/{{ scylla_cluster_name }}-ca.pem"
         common_name: "{{ scylla_cluster_name }}.internal"
         use_common_name_for_san: false  # since we do not specify SANs, don't use CN as a SAN
         basic_constraints:
@@ -69,8 +72,8 @@
 
     - name: Generate a Self Signed OpenSSL certificate for the CA
       community.crypto.x509_certificate:
-        path: "./ssl/ca/{{scylla_cluster_name }}-ca.crt"
-        privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
+        path: "{{ _localhost_cert_path }}/ssl/ca/{{scylla_cluster_name }}-ca.crt"
+        privatekey_path: "{{ _localhost_cert_path }}/ssl/ca/{{ scylla_cluster_name }}-ca.pem"
         csr_content: "{{ ca_csr.csr }}"
         provider: selfsigned
   when: _crt_and_key_exist == False and _ca_crt_and_key_exist == False
@@ -81,28 +84,28 @@
   block:
     - name: Create a directory for the key
       file:
-        path: "./ssl/{{ inventory_hostname }}"
+        path: "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}"
         state: directory
       delegate_to: localhost
 
     - name: Generate an OpenSSL private key.
       openssl_privatekey:
-        path: "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
+        path: "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
       delegate_to: localhost
 
     - name: Generate an OpenSSL Certificate Signing Request
       openssl_csr:
-        path: "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.csr"
-        privatekey_path: "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
+        path: "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.csr"
+        privatekey_path: "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
         common_name: "{{ inventory_hostname }}.{{ scylla_cluster_name }}.internal"
       delegate_to: localhost
 
     - name: Generate an OpenSSL certificate signed with our CA certificate
       openssl_certificate:
-        path: "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.crt"
-        csr_path: "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.csr"
-        ownca_path: "./ssl/ca/{{scylla_cluster_name }}-ca.crt"
-        ownca_privatekey_path: "./ssl/ca/{{ scylla_cluster_name }}-ca.pem"
+        path: "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.crt"
+        csr_path: "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.csr"
+        ownca_path: "{{ _localhost_cert_path }}/ssl/ca/{{scylla_cluster_name }}-ca.crt"
+        ownca_privatekey_path: "{{ _localhost_cert_path }}/ssl/ca/{{ scylla_cluster_name }}-ca.pem"
         provider: ownca
       delegate_to: localhost
   when: _crt_and_key_exist == False
@@ -116,14 +119,14 @@
     mode: '0644'
   become: true
   loop:
-    - "./ssl/ca/{{ scylla_cluster_name }}-ca.crt"
-    - "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.crt"
-    - "./ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
+    - "{{ _localhost_cert_path }}/ssl/ca/{{ scylla_cluster_name }}-ca.crt"
+    - "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.crt"
+    - "{{ _localhost_cert_path }}/ssl/{{ inventory_hostname }}/{{ inventory_hostname }}.pem"
 
 - name: Generate cqlshrc
   template:
     src: templates/cqlshrc.j2
-    dest: ./cqlshrc
+    dest: "{{ _localhost_cert_path }}/cqlshrc"
   delegate_to: localhost
   run_once: true
 


### PR DESCRIPTION
Today, if someone wants to use their own node certificates or sign the certificates with their own CA this is not possible, even though it's described on the documentation (https://github.com/scylladb/scylla-ansible-roles/wiki/ansible-scylla-node:-Deploying-a-Scylla-cluster#ssl-configuration-for-scylla-nodes) as possible.
This PR adds this functionality following the instructions already described in the documentation. 

Closes https://github.com/scylladb/scylla-ansible-roles/issues/11