### PR TITLE
ansible-scylla-node: Remove dependency on geerlingguy.swap and start using scylla_swap_setup instead

### DIFF
--- a/ansible-scylla-node/README.md
+++ b/ansible-scylla-node/README.md
@@ -18,7 +18,6 @@ Please check under `defaults/main.yml` and `vars/main.yml`, the variables are he
 Dependencies
 ------------
     Recommended in order to enable extra swap and configure a RAID array
-    - geerlingguy.swap
     - mrlesmithjr.mdadm
 
 
@@ -43,9 +42,6 @@ Example Playbook
       mountpoint: '/var/lib/scylla'
       state: 'present'
       opts: 'noatime,nofail'
-
-    #variables for the swap role
-    swap_file_size_mb: '1024'
 
     # variables for the Scylla node role (can be set here or in the role's vars/main.yml)
     scylla_repos:
@@ -81,7 +77,6 @@ Example Playbook
         state: present
       become: true
   roles:
-    - geerlingguy.swap
     - mrlesmithjr.mdadm
     - ../ansible-scylla-node
 ```

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -259,6 +259,10 @@ skip_cpuset: False
 skip_sysconfig: False
 skip_selinux: False
 skip_ntp: False
+skip_swap: False
+
+# Set it to 0 to let scylla choose the swap size
+swap_size_gb: 0
 
 # If defined, this enables the usage of a separate token_distributor instead of scylla's default random token distributor
 # The token distributor in the provided path must be named token_distributor.py and must have the following list of arguments:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -109,7 +109,7 @@
 
 - name: configure Scylla
   shell: |
-    scylla_setup --no-raid-setup --nic {{ scylla_nic }} --setup-nic-and-disks --no-ec2-check --no-kernel-check --no-ntp-setup --no-io-setup --no-node-exporter --no-coredump-setup --no-sysconfig-setup
+    scylla_setup --no-raid-setup --nic {{ scylla_nic }} --setup-nic-and-disks --no-ec2-check --no-kernel-check --no-ntp-setup --no-io-setup --no-node-exporter --no-coredump-setup --no-sysconfig-setup --no-swap-setup
   become: true
   when: ansible_facts.services["scylla-server.service"] is defined and ansible_facts.services["scylla-server.service"]["state"] != "running"
 
@@ -142,6 +142,10 @@
     shell: |
       scylla_coredump_setup --dump-to-raiddir
     when: skip_coredump is defined and skip_coredump|bool == false
+  - name: set up swap
+    shell: |
+      scylla_swap_setup{% if swap_size_gb is defined and swap_size_gb != 0 %} --swap-size {{ swap_size_gb }} {% endif %}
+    when: skip_swap is defined and skip_swap|bool == false
 
   - name: configure cpu scaling
     shell: |

--- a/example-playbooks/add_cluster_nodes/add_cluster_nodes.yml
+++ b/example-playbooks/add_cluster_nodes/add_cluster_nodes.yml
@@ -14,7 +14,6 @@
     # Please use the same parameters as were used for the rest of the existing cluster
 
   roles:
-    - geerlingguy.swap
     - ansible-scylla-node
 
 - name: Run cleanup on the old nodes

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -24,7 +24,6 @@
       when: replaced_node in scylla_seeds
 
   roles:
-    - geerlingguy.swap
     - ansible-scylla-node
 
 

--- a/example-playbooks/scylla_deploy/nodes.yml
+++ b/example-playbooks/scylla_deploy/nodes.yml
@@ -4,9 +4,6 @@
   become: true
   vars:
 
-    #variables for the swap role
-    swap_file_size_mb: '1024'
-
     # variables for the Scylla node role (can be set here or in the role's vars/main.yml)
     scylla_repos:
       - 'http://repositories.scylladb.com/scylla/repo/****/centos/scylladb-4.1.repo'
@@ -34,7 +31,6 @@
     scylla_manager_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
 
   roles:
-    - geerlingguy.swap
     - ansible-scylla-node
 
 


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-ansible-roles/issues/90