### PR TITLE
ansible-scylla-node: Fixes version check after a minor upgrade is done

### DIFF
--- a/ansible-scylla-node/tasks/upgrade/node_verification.yml
+++ b/ansible-scylla-node/tasks/upgrade/node_verification.yml
@@ -57,8 +57,8 @@
 - name: Verify that selected and installed versions are not different
   vars:
     version_specified: "{{ scylla_upgrade['major_version'] if upgrade_major else scylla_upgrade['version'] }}"
-    version_full_installed: "{{ node_scylla_release_version.json.split('-')[0] }}"
-    version_major_installed: "{{ version_full_installed.split('.')[0] }}.{{ version_full_installed.split('.')[1] }}"
+    version_full_installed: "{{ node_scylla_release_version.json }}"
+    version_major_installed: "{{ version_full_installed.split('-')[0].split('.')[0] }}.{{ version_full_installed.split('-')[0].split('.')[1] }}"
     version_installed: "{{ version_major_installed if upgrade_major else version_full_installed }}"
   ansible.builtin.fail:
     msg: "Version set ({{ version_specified }}) and version installed ({{ version_installed }}) are different, thus the upgrade failed."


### PR DESCRIPTION
When the upgrade feature was done, it was decided to not use the build number. If the full version is specified, the check will fail.

Fixes #308

Signed-off-by: Eduardo Benzecri <eduardo.benzecri@scylladb.com>