### PR TITLE
ansible-scylla-node: Adds an option to force the upgrade

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -17,6 +17,12 @@ upgrade_version: false
 #  true: 'major' upgrade
 upgrade_major: false
 
+# Defines if the upgrade process must be forced
+# Values:
+#  [default] true: always upgrade even if the same version is installed
+#  false: don't do anything
+upgrade_force: true
+
 # Defines if the upgrade process should rollback on failure
 # Values:
 #  [default] true: rollback on failure

--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -151,7 +151,7 @@
   ansible.builtin.fail:
     msg: "Version {{ scylla_upgrade['version'] }} specified for Scylla {{ scylla_upgrade['edition_friendly_name'] }} can't be used as a major upgrade since version detected is {{ scylla_detected['version'] }}."
   when: >
-      upgrade_major and
+      upgrade_major and not upgrade_force and
       (scylla_detected['version'] == scylla_upgrade['version'] or
       scylla_detected['major_version'] == scylla_upgrade['major_version'])
 
@@ -159,7 +159,7 @@
   ansible.builtin.fail:
     msg: "Version {{ scylla_upgrade['version'] }} specified for Scylla {{ scylla_upgrade['edition_friendly_name'] }} can't be used as a minor upgrade since version detected is {{ scylla_detected['version'] }}."
   when: >
-      not upgrade_major and
+      not upgrade_major and not upgrade_force and
       (scylla_detected['version'] == scylla_upgrade['version'] or
       scylla_detected['major_version'] != scylla_upgrade['major_version'])
 


### PR DESCRIPTION
This patch will add the ability of skipping any version control when an upgrade should take place.

Fixes #210

Signed-off-by: Eduardo Benzecri <eduardo.benzecri@scylladb.com>