### PR TITLE
ansible-scylla-node: Updates post-upgrade version check

### DIFF
--- a/ansible-scylla-node/tasks/upgrade/node_verification.yml
+++ b/ansible-scylla-node/tasks/upgrade/node_verification.yml
@@ -62,4 +62,4 @@
     version_installed: "{{ version_major_installed if upgrade_major else version_full_installed }}"
   ansible.builtin.fail:
     msg: "Version set ({{ version_specified }}) and version installed ({{ version_installed }}) are different, thus the upgrade failed."
-  when: version_specified != version_installed
+  when: version_installed not in version_specified


### PR DESCRIPTION
Instead of comparing if the versions are equal, the version installed should match partially or totally the detected one.

This path was done because of:
Scylla package version (obtained as an Ansible's fact): 2021.1.17-0.20221221.5318a7fec-1
Scylla version (scylla --version output): 2021.1.17-0.20221221.5318a7fec

Fixes: #212

Signed-off-by: Eduardo Benzecri <eduardo.benzecri@scylladb.com>