### PR TITLE
scylla-node: improve idempotence of RAID setup

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -23,16 +23,14 @@
   block:
     - name: check for current raid
       shell: |
-        C=$(cat /proc/mdstat |grep md0| wc -w)
-        echo $((0 + C - 4))
-      register: present_raid_disks
+        lsblk | grep -w "/var/lib/scylla" | wc -l
+      register: present_scylla_disks
 
-    - name: run raid setup
+    - name: run raid setup if there is no scylla mount yet
       shell: |
         scylla_raid_setup --disks "{{ scylla_raid_setup | join(',') }}" --update-fstab
       become: true
-      when: scylla_raid_setup is defined and scylla_raid_setup|length > 0 and scylla_raid_setup|length != present_raid_disks.stdout|int
-      ignore_errors: true
+      when: scylla_raid_setup is defined and scylla_raid_setup|length > 0 and present_scylla_disks.stdout|int == 0
 
 - name: IO settings probe
   block:


### PR DESCRIPTION
Run scylla_raid_setup only if there isn't a scylla mount yet.

The previous logic tried to check the number of disk in md0 SW RAID. This was bogus for multiple reasons:

1) Scylla RAID can be *not* md0 but any mdX. By default scylla_raid_setup
   is going to try an unused mdX for X'es between 0 and 9.
2) This logic breaks even worse for a single NVMe card configurations -
   these won't even use SW RAID.

This patch changes the logic to explicitly check for mounts with 'scylla' in their mount point name. If exists - scylla_raid_setup won't be called.

This will avoid scylla_raid_setup from being called if that mount had been created using Scylla Role, because Role calls 'scylla_raid_setup' with a default mount point name, which will be '/var/lib/scylla'.

In any other case - scylla_raid_setup is going to be invoked and will try to create a RAID on top of requested devices. If it fails - the play will fail too.

Fixed #219