### PR TITLE
run_decommission.yml: Batch of small fixes

### DIFF
--- a/example-playbooks/run_decommission/run_decommission.yml
+++ b/example-playbooks/run_decommission/run_decommission.yml
@@ -34,9 +34,9 @@
         async_task:
           script:  files/decommission.sh
           alias: scylla_decommission
-          async: async_timeout
-          retries: async_task_retries
-          delay: async_task_delay
+          async: "{{ async_timeout | int }}"
+          retries: "{{ async_task_retries | int }}"
+          delay: "{{ async_task_delay | int }}"
         register: decommission_output
       - name: Decommission logs
         ansible.builtin.debug: var=decommission_output

--- a/example-playbooks/run_decommission/run_decommission.yml
+++ b/example-playbooks/run_decommission/run_decommission.yml
@@ -29,6 +29,7 @@
           state: absent
           path: async_lock_directory
         when: remove_async_lock_directory
+        become: true
       - name: Run decommission
         async_task:
           script:  files/decommission.sh


### PR DESCRIPTION
This PR contains:
- A fix that will allow the playbook to remove the async lock directory granting the required permissions
- A fix will force and pass several async module variables as int