### PR TITLE
ansible-scylla-node: Allow skipping io_properties setup

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -295,6 +295,7 @@ devmode: False
 skip_cpuset: False
 skip_sysconfig: False
 skip_selinux: False
+skip_io_properties: False
 skip_ntp: False
 skip_swap: False
 

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -88,6 +88,7 @@
     group: root
     mode: '0644'
   become: true
+  when: skip_io_properties is defined and skip_io_properties|bool == false
 
 - name: configure NTP
   shell: |


### PR DESCRIPTION
If io_properties is already configured, it might be useful to be able to skip its setup.
This patch adds a variable `skip_io_properties` which allows this.