### PR TITLE
Revert "ansible-scylla-node: Use already existing io_properties.yaml by default"

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -201,14 +201,6 @@ scylla_io_probe: True
 # and then the configuration files will be propagated for the other nodes of each datacenter.
 scylla_io_probe_dc_aware: False
 
-# If set to True, the role will always replace the io.conf file and you will
-# lose any manual values you might have configured on the nodes.
-always_replace_io_conf: False
-
-# If set to True, the role will always replace the io_properties.yaml file and you will
-# lose any manual values you might have configured on the nodes.
-always_replace_io_properties: False
-
 # These can be arbitrarily set if scylla_io_probe is set to False
 # io_properties:
 #   disks:

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -210,7 +210,7 @@ always_replace_io_conf: False
 always_replace_io_properties: False
 
 # These can be arbitrarily set if scylla_io_probe is set to False
-# io_properties: |
+# io_properties:
 #   disks:
 #     - mountpoint: /var/lib/scylla/data
 #       read_iops: 10962999

--- a/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
@@ -61,7 +61,7 @@ provisioner:
         scylla_edition: "oss"
         scylla_version: "latest"
         scylla_io_probe: false
-        io_properties: |
+        io_properties:
           disks:
             - mountpoint: "/var/lib/scylla/data"
               read_iops: 2000

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -83,7 +83,7 @@
     line: "{% if scylla_io_probe|bool and scylla_io_probe_dc_aware|bool %}{{ hostvars[dc_to_node_list[dc][0]]['io_conf'] }}{% else %}{{ io_conf }}{% endif %}"
     create: yes
   become: true
-  when: io_conf is defined
+  when: io_conf is defined and (_io_conf_file.stat.exists|bool == false or always_replace_io_conf|bool)
 
 - name: For every node, check if io_properties.yaml already exists
   stat:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -71,11 +71,6 @@
   run_once: "{{ not scylla_io_probe_dc_aware|bool }}"
   become: true
 
-- name: For every node, check if io.conf already exists
-  stat:
-    path: /etc/scylla.d/io.conf
-  register: _io_conf_file
-
 - name: Set io.conf
   lineinfile:
     path: /etc/scylla.d/io.conf
@@ -83,12 +78,7 @@
     line: "{% if scylla_io_probe|bool and scylla_io_probe_dc_aware|bool %}{{ hostvars[dc_to_node_list[dc][0]]['io_conf'] }}{% else %}{{ io_conf }}{% endif %}"
     create: yes
   become: true
-  when: io_conf is defined and (_io_conf_file.stat.exists|bool == false or always_replace_io_conf|bool)
-
-- name: For every node, check if io_properties.yaml already exists
-  stat:
-    path: /etc/scylla.d/io_properties.yaml
-  register: _io_properties_file
+  when: io_conf is defined
 
 - name: Set io_properties
   template:
@@ -98,7 +88,6 @@
     group: root
     mode: '0644'
   become: true
-  when: _io_properties_file.stat.exists|bool == false or always_replace_io_properties|bool
 
 - name: configure NTP
   shell: |


### PR DESCRIPTION


Reverts scylladb/scylla-ansible-roles#236