### PR TITLE
ansible-scylla-node: Use already existing io_properties.yaml and io.conf by default

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -201,6 +201,14 @@ scylla_io_probe: True
 # and then the configuration files will be propagated for the other nodes of each datacenter.
 scylla_io_probe_dc_aware: False
 
+# If set to True the content of io.conf is going to be aligned with the first node or the
+# first node in each DC (depending on the value of scylla_io_probe_dc_aware)
+always_replace_io_conf: False
+
+# If set to True the content of io_properties.yaml is going to be aligned with the first node or the
+# first node in each DC (depending on the value of scylla_io_probe_dc_aware)
+always_replace_io_properties: False
+
 # These can be arbitrarily set if scylla_io_probe is set to False
 # io_properties:
 #   disks:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -71,6 +71,19 @@
   run_once: "{{ not scylla_io_probe_dc_aware|bool }}"
   become: true
 
+- name: For every node, check if io.conf already exists and if it's not empty
+  block:
+  - stat:
+      path: /etc/scylla.d/io.conf
+    register: _io_conf_file
+
+  # During installation, scylla creates an io.conf filled only with comments and this file needs to be replaced
+  - name: Check if file is empty or filled only with comments
+    shell: "cat /etc/scylla.d/io.conf | grep -v ^#"
+    register: _io_conf_out
+    ignore_errors: true
+    when: _io_conf_file.stat.exists|bool
+
 - name: Set io.conf
   lineinfile:
     path: /etc/scylla.d/io.conf
@@ -78,7 +91,12 @@
     line: "{% if scylla_io_probe|bool and scylla_io_probe_dc_aware|bool %}{{ hostvars[dc_to_node_list[dc][0]]['io_conf'] }}{% else %}{{ io_conf }}{% endif %}"
     create: yes
   become: true
-  when: io_conf is defined
+  when: io_conf is defined and (_io_conf_file.stat.exists|bool == false or _io_conf_out.stdout|length == 0 or always_replace_io_conf|bool)
+
+- name: For every node, check if io_properties.yaml already exists
+  stat:
+    path: /etc/scylla.d/io_properties.yaml
+  register: _io_properties_file
 
 - name: Set io_properties
   template:
@@ -88,6 +106,7 @@
     group: root
     mode: '0644'
   become: true
+  when: _io_properties_file.stat.exists|bool == false or always_replace_io_properties|bool
 
 - name: configure NTP
   shell: |


### PR DESCRIPTION
Currently, by default, the role will always try to replace the io_properties.yaml and io.conf files according to scylla_io_setup output or pre-defined io_properties and io_conf variables. However, it makes more sense to avoid touching these files if they already exist, since the user might be, for example, performing some kind of test which requires io_properties/io.conf to use different values for different nodes.
This patch changes the default behavior, and now these files will only be replaced if the flags `always_replace_io_properties` and `always_replace_io_conf', added on this patch, are set to True.