### PR TITLE
Add default users

### DIFF
--- a/example-playbooks/manage_users/README.md
+++ b/example-playbooks/manage_users/README.md
@@ -1,0 +1,59 @@
+# Manage users
+
+This is an ansible playbook that allows the creation of cql users and deletes the default cassandra user.
+
+## Prerequisites
+
+* A scylla cluster with authentication enabled.
+
+## Parameters / Default Behavior
+
+* `scylla_nic`: The network interface being used by scylla.
+* `scylla_nic_ipv4_addr`: IPv4 address for the network interface being used by scylla.
+* `delete_cassandra_user`: A boolean indicating if the default cassandra user must be deleted or not.
+* `scylla_admin_username`: The username of the superuser which will be replacing the default cassandra user.
+* `users`: A map with the users (besides `scylla_admin_username`) which are going to be added.
+           Every user is a map containing the following entries:
+    * `superuser` -> a boolean indicating if the new user is a superuser
+    * `permissions` (optional) -> A list with the permissions. Every permission is represented by a list
+                                  with 2 positions, where the first position is the name of the permission
+                                  and the second position is the resource for which this permission is being added.
+                                  A list with the available permissions can be found in {https://docs.scylladb.com/stable/operating-scylla/security/authorization.html#permissions}.
+
+In order to connect via cqlsh and update the credentials, this playbook will try to get the `rpc_address` on scylla.yaml.
+If this value is not set, then it'll be assumed that localhost is being used, since this is the default value on scylla and the
+playbook will try to find out the IP address by getting the IPv4 for the default network interface.
+If you want, you can override the variables `scylla_nic` and `scylla_nic_ipv4_addr` to choose the nic and ipv4 address which you'd like
+the playbook to use in case rpc is not set.
+If `rpc_address` is set to 0.0.0.0, this playbook will use `broadcast_rpc_address`.
+
+By default, this playbook will create the users `scylla_admin` (superuser), `scylla_cql_monitor` and `customer_admin`.
+Their default permissions are listed in `vars/main.yml`.
+You can override the variable `users` in order to add a different list of users with a different set of permissions.
+
+Every user defined in this playbook must be also defined in the inventory file under the section `[cql_credentials]` followed by its password.
+E.g.:
+```
+[cql_credentials]
+scylla_admin=password1
+scylla_cql_monitor=password2
+customer_admin=password3
+```
+
+## Allowed operations
+
+* Addition of users
+* Addition of permissions for any user (Removing permissions isn't supported)
+* Changing password for any user except `scylla_admin`
+
+## Inventory
+
+Put public IP addresses of all nodes under the section `[scylla]` in the inventory.
+
+## Running
+
+Run the playbook:
+
+```
+ansible-playbook -i inventory.ini manage_users.yaml [-e "@users.yml"]
+```

--- a/example-playbooks/manage_users/create_user.yml
+++ b/example-playbooks/manage_users/create_user.yml
@@ -1,0 +1,19 @@
+---
+- name: Create user {{ username }}
+  block:
+  - set_fact:
+      superuser_str: "{% if superuser|bool %}SUPERUSER{% else %}NOSUPERUSER{% endif %}"
+
+  - shell: |
+      cqlsh {{ cql_address }} {{ cql_port }} -u {{ admin_username }} -p {{ admin_password }} -e "CREATE USER IF NOT EXISTS {{ username }} WITH PASSWORD '{{ password }}' {{ superuser_str }};"
+
+  - shell: |
+      cqlsh {{ cql_address }} {{ cql_port }} -u {{ admin_username }} -p {{ admin_password }} -e "ALTER ROLE {{ username }} WITH PASSWORD = '{{ password }}'"
+
+- name: Grant permissions
+  shell: |
+    cqlsh {{ cql_address }} {{ cql_port }} -u {{ admin_username }} -p {{ admin_password }} -e "GRANT {{ outer_item[0] }} on {{ outer_item[1] }} to {{ username }};"
+  loop: "{{ permissions | list }}"
+  loop_control:
+    loop_var: outer_item
+  when: permissions is defined

--- a/example-playbooks/manage_users/manage_users.yml
+++ b/example-playbooks/manage_users/manage_users.yml
@@ -1,0 +1,90 @@
+---
+
+#     This playbook allows the creation of cql users and deletes the default cassandra user as recommended in scylla's
+#     documentation -> {https://docs.scylladb.com/stable/operating-scylla/security/enable-authorization.html#enabling-authorization}.
+#     By default this playbook will add the users scylla_admin (superuser), scylla_cql_monitor and customer_admin,
+#     but you can change the list of users and permissions by overriding the variable users.
+#     Every user defined in this playbook must be also defined in the inventory file under the section [cql_credentials] followed
+#     by its password.
+#     E.g.:
+#     [cql_credentials]
+#     scylla_admin=password1
+#     scylla_cql_monitor=password2
+#     customer_admin=password3
+#
+#     Operations allowed:
+#       * Addition of users
+#       * Addition of permissions for any user (Removing permissions isn't supported)
+#       * Changing password for any user except scylla_admin
+#
+#     Usage:
+#       ansible-playbook -i inventory.ini manage_users.yaml [-e "@users.yml"]
+
+- name: Add users from inventory and delete cassandra user
+  hosts: scylla
+  vars_files:
+    - vars/main.yml
+  tasks:
+    - name: Get cql address and check if authentication is enabled
+      block:
+        - command: cat /etc/scylla/scylla.yaml
+          register: _scylla_yaml_out
+
+        - set_fact:
+            _scylla_yaml_map: "{{ _scylla_yaml_out.stdout | from_yaml }}"
+
+        # rpc_address is the listen address for client connections. If not set
+        # the localhost address is used and if set to 0.0.0.0 the broadcast_rpc_address
+        # must be set and used.
+        - set_fact:
+            cql_address: "{{ _scylla_yaml_map.rpc_address|default(scylla_nic_ipv4_addr) }}"
+
+        - set_fact:
+            cql_address: "{{ _scylla_yaml_map.broadcast_rpc_address }}"
+          when: cql_address == "0.0.0.0"
+
+        - set_fact:
+            cql_port: "{{ _scylla_yaml_map.native_transport_port|default(9042)|int }}"
+
+        - set_fact:
+            _authentication_enabled: |
+              {% if (_scylla_yaml_map.authenticator is defined and (_scylla_yaml_map.authenticator == 'TransitionalAuthenticator' or _scylla_yaml_map.authenticator == 'PasswordAuthenticator')) or
+              (_scylla_yaml_map.authorizer is defined and (_scylla_yaml_map.authorizer == 'TransitionalAuthorizer' or _scylla_yaml_map.authorizer == 'CassandraAuthorizer')) %}True{% else %}False{% endif %}
+
+    - fail:
+        msg: "Authentication is not enabled!"
+      when: _authentication_enabled|bool == false
+      run_once: true
+
+    - name: Set password for scylla_admin
+      set_fact:
+        scylla_admin_password: "{{ lookup('ini', scylla_admin_username, section='cql_credentials', allow_no_value=true, default=omit, file=inventory_file) }}"
+
+    - name: Create scylla_admin user
+      include_tasks: create_user.yml
+      vars:
+        superuser: true
+        admin_username: "cassandra"
+        admin_password: "cassandra"
+        username: "{{ scylla_admin_username }}"
+        password: "{{ scylla_admin_password }}"
+      ignore_errors: true
+      run_once: true
+
+    - name: Create other users
+      include_tasks: create_user.yml
+      vars:
+        superuser: "{{ item.value.superuser }}"
+        admin_username: "{{ scylla_admin_username }}"
+        admin_password: "{{ scylla_admin_password }}"
+        username: "{{ item.key }}"
+        password: "{{ lookup('ini', item.key, section='cql_credentials', allow_no_value=true, default=omit, file=inventory_file) }}"
+        permissions: "{{ item.value.permissions }}"
+      loop: "{{ users | dict2items }}"
+      run_once: true
+
+    - name: Delete cassandra user
+      shell: |
+        cqlsh {{ cql_address }} {{ cql_port }} -u {{ scylla_admin_username }} -p {{ scylla_admin_password }} -e "DROP ROLE IF EXISTS 'cassandra';"
+      run_once: true
+      when: delete_cassandra_user|bool

--- a/example-playbooks/manage_users/vars/main.yml
+++ b/example-playbooks/manage_users/vars/main.yml
@@ -1,0 +1,24 @@
+scylla_nic: "{{ ansible_default_ipv4.interface }}"
+scylla_nic_ipv4_addr: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
+
+delete_cassandra_user: true
+
+scylla_admin_username: scylla_admin
+
+users:
+  scylla_cql_monitor:
+    superuser: false
+    permissions:
+      - ['SELECT', 'KEYSPACE SYSTEM']
+  customer_admin:
+    superuser: false
+    permissions:
+      - ['CREATE', 'ALL ROLES']
+      - ['AUTHORIZE', 'ALL ROLES']
+      - ['DESCRIBE', 'ALL ROLES']
+      - ['AUTHORIZE', 'ALL KEYSPACES']
+      - ['CREATE', 'ALL KEYSPACES']
+      - ['ALTER', 'ALL KEYSPACES']
+      - ['SELECT', 'ALL KEYSPACES']
+      - ['MODIFY', 'ALL KEYSPACES']
+      - ['AUTHORIZE', 'ALL KEYSPACES']


### PR DESCRIPTION
This PR adds a playbook which allows the creation of cql users and deletes the default cassandra user as recommended in scylla's documentation -> {https://docs.scylladb.com/stable/operating-scylla/security/enable-authorization.html#enabling-authorization}.
By default this playbook will add the users scylla_admin (superuser), scylla_cql_monitor and customer_admin,
but you can change the list of users and permissions by overriding the variable users.
Every user defined in this playbook must be also defined in the inventory file under the section [cql_credentials] followed
by its password.
```
E.g.:
[cql_credentials]
scylla_admin=password1
scylla_cql_monitor=password2
customer_admin=password3
```

Operations allowed:
  * Addition of users
  * Addition of permissions for any user (Removing permissions isn't supported)
  * Changing password for any user except scylla_admin