### PR TITLE
manage_user.yml: Use import_task instead of include_tasks for creating admin_user

### DIFF
--- a/example-playbooks/manage_users/manage_users.yml
+++ b/example-playbooks/manage_users/manage_users.yml
@@ -61,7 +61,7 @@
         scylla_admin_password: "{{ lookup('ini', scylla_admin_username, section='cql_credentials', allow_no_value=true, default=omit, file=inventory_file) }}"
 
     - name: Create scylla_admin user
-      include_tasks: create_user.yml
+      import_tasks: create_user.yml
       vars:
         superuser: true
         admin_username: "cassandra"


### PR DESCRIPTION
Passing ignore errors to the task included works only with import_tasks. This patch replaces include_tasks with import_tasks in order for the ignore_errors to work. This ignore_errors is necessary because it's ok for the task of creating scylla_admin to fail if scylla_admin already exists.