### PR TITLE
ansible-scylla-monitoring: Allow gathering names/ips from the inventory to generate scylla_servers.yml

### DIFF
--- a/ansible-scylla-monitoring/defaults/main.yml
+++ b/ansible-scylla-monitoring/defaults/main.yml
@@ -26,6 +26,11 @@ scylla_monitoring_config_path:  "{{ scylla_monitoring_deploy_path }}/config"
 scylla_monitoring_prom_rules_path:  "{{ scylla_monitoring_config_path }}/prom_rules"
 scylla_monitoring_alertdata_path: "{{ scylla_monitoring_deploy_path }}/alertdata"
 
+# If set to True, the role will generate scylla_servers.yml based on the output of nodetool status
+# If set to False, the dc variable must be defined in the inventory for each one of the nodes and the role
+# will use the information from the inventory to generate scylla_servers.yml.
+use_nodetool_status_with_genconfig: false
+
 # List of monitoring dashboards to enable
 scylla_monitoring_dashboards_versions:
   - '2021.1'

--- a/ansible-scylla-monitoring/tasks/common.yml
+++ b/ansible-scylla-monitoring/tasks/common.yml
@@ -86,7 +86,7 @@
     mode: '0644'
   when: scylla_servers_stat.stat.exists|bool
 
-- name: generate scylla_servers.yml for monitoring
+- name: generate scylla_servers.yml for monitoring using nodetool status
   block:
     - command: nodetool status
       register: nodetool_status_out
@@ -95,7 +95,24 @@
     - shell: "{{ base_dir }}/genconfig.py -c {{ scylla_cluster_name }} -NS -o {{ scylla_monitoring_config_path }}/scylla_servers.yml"
       args:
         stdin: "{{ nodetool_status_out.stdout }}"
-  when: scylla_servers_stat.stat.exists|bool == false
+  when: use_nodetool_status_with_genconfig|bool and scylla_servers_stat.stat.exists|bool == false
+  run_once: true
+
+- name: generate scylla_servers.yml for monitoring using the inventory
+  block:
+    # Resulting map -> {'-dc dc1': [node1, node2, node3], '-dc dc2': [node4, node5, node6]}
+    - name: Create a map from dc to its list of nodes
+      set_fact:
+        dc_to_node_list: "{{ dc_to_node_list | default({}) | combine( {'-dc ' + hostvars[item]['dc']: (dc_to_node_list | default({}))['-dc ' + hostvars[item]['dc']] | default([]) + [item]} ) }}"
+      loop: "{{ groups['scylla'] }}"
+
+    # Resulting str -> "-dc dc1:node1,node2,node3 -dc dc2:node4,node5,node6"
+    - name: Convert dc_to_node_list to a string to be used as argument for genconfig.py
+      set_fact:
+        dc_to_node_list_str: "{{ dc_to_node_list.keys() | zip(dc_to_node_list.values()) | map('join', ':') | join(' ') | replace('[','') | replace(']','') | replace(\"'\", '') | replace (', ', ',') }}"
+
+    - shell: "{{ base_dir }}/genconfig.py -c {{ scylla_cluster_name }} -o {{ scylla_monitoring_config_path }}/scylla_servers.yml {{ dc_to_node_list_str }}"
+  when: use_nodetool_status_with_genconfig|bool == false and scylla_servers_stat.stat.exists|bool == false
   run_once: true
 
 - name: set up scylla_manager_servers.yml


### PR DESCRIPTION
Currently we're using the information from nodetool status to generate scylla_servers.yml.
However, it might be useful to use the information from the inventory, if we want, for example,
to use the dns names. This patch adds a variable `use_nodetool_status_with_genconfig` and sets it
to False as default. Whenever this variable is set to False, the role will generate scylla_servers.yml
based on the information from the inventory. Note that in order for this to work, the dc variable
must be defined for all the nodes in the inventory.
e.g.:
```
[scylla]
node1 dc=dc1
node2 dc=dc1
node3 dc=dc1
```