### PR TITLE
ansible-scylla-node: Starts 'scylla-fstrim.timer' service automatically

### DIFF
--- a/ansible-scylla-node/handlers/main.yml
+++ b/ansible-scylla-node/handlers/main.yml
@@ -31,6 +31,13 @@
     state: started
     enabled: yes
 
+- name: Enable and start 'scylla-fstrim.timer' service
+  ansible.builtin.service:
+    name: scylla-fstrim.timer
+    state: started
+    enabled: yes
+  become: true
+
 - name: scylla-manager-agent start
   become: true
   service:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -184,6 +184,7 @@
   - name: configure fstrim
     shell: |
       scylla_fstrim_setup
+    notify: Enable and start 'scylla-fstrim.timer' service
 
   - name: configure sysconfig
     shell: |


### PR DESCRIPTION
This patch enforces 'scylla-fstrim.timer' service to be enabled and started by default after 'scylla_fstrim_setup' is executed.

Ref: #246