### PR TITLE
manage_users.yml: Add ALTER permission on ALL ROLES to customer_admin

### DIFF
--- a/example-playbooks/manage_users/vars/main.yml
+++ b/example-playbooks/manage_users/vars/main.yml
@@ -22,3 +22,4 @@ users:
       - ['SELECT', 'ALL KEYSPACES']
       - ['MODIFY', 'ALL KEYSPACES']
       - ['AUTHORIZE', 'ALL KEYSPACES']
+      - ['ALTER', 'ALL ROLES'] # This is a workaround and should be removed once {https://github.com/scylladb/scylladb/issues/14279} is fixed


### PR DESCRIPTION
Currently, the customer_admin user is not able to change the password for other users. This patch fixes this by giving ALTER permission on ALL roles to this user. This is not ideal, since now the customer_admin user will be able to change passwords even for superusers, but it's the only option we have until the following issues are fixed:

- https://github.com/scylladb/scylladb/issues/14277
- https://github.com/scylladb/scylladb/issues/14279