### PR TITLE
ansible-scylla-node: Improves "legacy" support for 'node-exporter'

### DIFF
--- a/ansible-scylla-node/handlers/main.yml
+++ b/ansible-scylla-node/handlers/main.yml
@@ -24,12 +24,38 @@
     name: scylla-server
     state: stopped
 
-- name: node_exporter start
+- name: Enable and start 'node-exporter.service' service (legacy)
+  block:
+  - name: Disable and stop 'scylla-node-exporter.service' service
+    ansible.builtin.service:
+      name: scylla-node-exporter.service
+      state: stopped
+      enabled: no
+    when: ansible_facts.services["scylla-node-exporter.service"] is defined
+
+  - name: Enable and start 'node-exporter.service' service (legacy)
+    ansible.builtin.service:
+      name: node-exporter.service
+      state: started
+      enabled: yes
   become: true
-  service:
-    name: node-exporter
-    state: started
-    enabled: yes
+  when: ansible_facts.services["node-exporter.service"] is defined
+
+- name: Enable and start 'scylla-node-exporter.service' service
+  block:
+  - name: Disable and stop 'node-exporter.service' service (legacy)
+    ansible.builtin.service:
+      name: node-exporter.service
+      state: stopped
+      enabled: no
+    when: ansible_facts.services["node-exporter.service"] is defined
+
+  - name: Enable and start 'scylla-node-exporter.service' service
+    ansible.builtin.service:
+      name: scylla-node-exporter.service
+      state: started
+      enabled: yes
+  when: ansible_facts.services["scylla-node-exporter.service"] is defined
 
 - name: Enable and start 'scylla-fstrim.timer' service
   ansible.builtin.service:

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -65,6 +65,7 @@
   - name: Install Scylla packages
     include_tasks: Debian_install.yml
   become: true
+  notify: Enable and start 'scylla-node-exporter.service' service
 
 # TODO: Implement this for the debian based distros
 # - name: install prerequisite python-yaml

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -111,6 +111,7 @@
       lock_timeout: 60
     when: scylla_version != 'latest' and scylla_edition == 'enterprise'
   become: true
+  notify: Enable and start 'scylla-node-exporter.service' service
 
 - name: Configure SELinux
   shell: |

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -114,23 +114,20 @@
   become: true
   when: skip_ntp is defined and skip_ntp|bool == false
 
-- name: node exporter setup
-  shell: |
+- name: Check if 'node_exporter_install' exists (legacy)
+  ansible.builtin.stat:
+    path: /usr/sbin/node_exporter_install
+  register: node_exporter_install
+
+- name: Run 'node_exporter_install' (legacy)
+  ansible.builtin.shell: |
     node_exporter_install --force
-  when: install_type == 'online'
   become: true
   notify:
-    - node_exporter start
-  ignore_errors: true
-  #TODO: stop ignoring errors when the node_exporter_install script fix is available in all actual versions, resp. use only for < 5.0 / 2022
-
-- name: node exporter setup from 5.0/2022
-  service:
-        name: scylla-node-exporter
-        state: started
-  become: true
-  ignore_errors: true
-  #TODO: stop ignoring errors when a version check is added
+    - Enable and start 'node-exporter.service' service (legacy)
+  when:
+    - install_type == 'online'
+    - node_exporter_install.stat.exists
 
 - name: configure Scylla
   shell: |

--- a/ansible-scylla-node/tasks/upgrade/post_upgrade.yml
+++ b/ansible-scylla-node/tasks/upgrade/post_upgrade.yml
@@ -5,6 +5,8 @@
   ansible.builtin.service:
     name: scylla-server
     state: started
-  notify: scylla-manager-agent restart
+  notify:
+    - scylla-manager-agent restart
+    - Enable and start 'node-exporter.service' service (legacy)
+    - Enable and start 'scylla-node-exporter.service' service
   become: true
-


### PR DESCRIPTION
This patch improves how 'node_exporter_install' is called and how 'node-exporter' service is started.

Fixes: #249