### PR TITLE
scylla-monitoring: rule_config.yml.j2: add routes for string severities

### DIFF
--- a/ansible-scylla-monitoring/templates/rule_config.yml.j2
+++ b/ansible-scylla-monitoring/templates/rule_config.yml.j2
@@ -55,3 +55,9 @@ route:
   - match:
       severity: "3"
     receiver: team-X-mails-urgent
+  - match:
+      severity: "info"
+    receiver: team-X-mails-urgent
+  - match:
+      severity: "warn"
+    receiver: team-X-mails-urgent


### PR DESCRIPTION
Since "prometheus.rules.yml: Use severity as string instead of numbers" Alert Manager is going to use string severities values, like "warn", "error", etc.

However the same patch introduced a regression by inverting the severities: https://github.com/scylladb/scylla-monitoring/issues/2029

While we are waiting for a fix let's "hack" it so that things continue working.