### PR TITLE
scylla-node: scylla_raid_setup: allow overriding "online discard" option

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -303,6 +303,7 @@ scylla_manager_agent_config: |
   # - /dev/nvme0n1
   # - /dev/nvme0n2
   # - /dev/nvme0n3
+scylla_raid_online_discard: False
 
 skip_coredump: False
 devmode: False

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -27,10 +27,24 @@
       register: present_scylla_disks
 
     - name: run raid setup if there is no scylla mount yet
-      shell: |
-        scylla_raid_setup --disks "{{ scylla_raid_setup | join(',') }}" --update-fstab
-      become: true
+      block:
+      - name: check if online-discard configuration is supported
+        shell: |
+          scylla_raid_setup --help
+        become: true
+        register: _scylla_raid_setup_help
+
+      - name: Explicitly set online discard option to {{ scylla_raid_online_discard }} if supported
+        set_fact:
+          _disable_online_discard: "--online-discard {{ scylla_raid_online_discard }}"
+        when: _scylla_raid_setup_help.stdout is search("--online-discard")
+
+      - name: run raid setup if there is no scylla mount yet
+        shell: "scylla_raid_setup --disks {{ scylla_raid_setup | join(',') }} --update-fstab {{ _disable_online_discard }}"
+        become: true
       when: scylla_raid_setup is defined and scylla_raid_setup|length > 0 and present_scylla_disks.stdout|int == 0
+      vars:
+        _disable_online_discard: ""
 
 # Resulting map -> {'dc1': [node1, node2, node3], 'dc2': [node4, node5, node6]}
 - name: Create a map from dc to its list of nodes


### PR DESCRIPTION
This is a dangerous option that should not be used by default.

This allows specifying whether one wants it to be used or not. By default we will not use it.