### PR TITLE
ansible-scylla-node: Add support for encryption at rest

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -345,6 +345,40 @@ handle_table_keys: false
 localhost_table_key_directory: "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/table_encryption_keys"
 table_key_directory: "/etc/scylla/table_encryption_keys"
 
+# Encrypt system resources:
+# System encryption is applied to semi-transient on-disk data, such as commit logs, batch logs, and hinted handoff data.
+# Note that for system info encryption, only the following key providers are supported:
+# LocalKeyProvider: Stores the key on the same machine as the data. Please use the system_info_encrypt_local config.
+# KMIPKeyProvider: External key management server. Please use the system_info_encryption_kmip config.
+# KMSKeyProvider: Uses key(s) provided by the AWS KMS service. Please use the system_info_encryption_kms config.
+
+# If you decide to use a LocalKeyProvider and also want the role to manage the local key that will be used, make sure you
+# have {{ handle_system_keys }}, {{ localhost_system_key_directory }} and {{ system_key_directory }} set appropriately.
+
+# LocalKeyProvider:
+system_info_encryption_local:
+  enabled: false
+  secret_key_file: "{{ system_key_directory }}/system_info_key"
+  cipher_algorithm: AES/CBC/PKCS5Padding
+  secret_key_strength: 128
+
+# KMIPKeyProvider:
+# Make sure you set kmip_hosts accordingly
+system_info_encryption_kmip:
+  enabled: false
+  cipher_algorithm: AES
+  secret_key_strength: 128
+  kmip_host: yourkmipServerIP.com
+
+# KMSKeyProvider:
+# Make sure you set kms_hosts accordingly
+system_info_encryption_kms:
+  enabled: false
+  cipher_algorithm: AES/CBC/PKCS5Padding
+  secret_key_strength: 128
+  kms_host: myScylla
+
+
 # If Scylla Manager will be used, set the following variables
 scylla_manager_enabled: true
 # deprecated in favour of below, it will be dropped soon, below should be used

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -310,6 +310,41 @@ handle_system_keys: false
 localhost_system_key_directory: "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/system_encryption_keys"
 system_key_directory: "/etc/scylla/system_encryption_keys"
 
+# Table keys are used for encrypting SSTables. Depending on your key provider, this key is stored in different locations:
+# Replicated key provider - encrypted_keys table
+# KMIP key provider - KMIP server
+# KMS key provider - AWS
+# Local key provider - in a local file with multiple keys. You can provide your own key or Scylla can make one for you.
+
+# You can use this role for managing your local table keys. In order to do so, you need to set {{ handle_table_keys }} to true
+# and place all of your local table keys under the {{ localhost_table_key_directory }} folder. The role will copy all the
+# local table keys to the {{ table_key_directory }} folder.
+# Note that by default the {{ inventory_hostname }} is part of the localhost_table_key_directory. This allows you to define
+# different keys per host.
+# e.g.:
+# If your localhost_table_key_directory is set to "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/table_encryption_keys"
+# and you have the following file tree:
+#
+# ├── encryption_at_rest
+# │   ├── node1
+# │   │   └── table_encryption_keys
+# │   │       └── key1
+# │   ├── node2
+# │   │   └── table_encryption_keys
+# │   │       └── key2
+# │   └── node3
+# │       └── table_encryption_keys
+# │           └── key3
+# └── inventory.ini
+#
+# At the end of the process node1 will have key1, node2 will have key2 and node3 will have key3.
+# On the other hand, if you want to have the same keys for all the hosts you can define a {{ localhost_table_key_directory }}
+# without the {{ inventory_hostname }} in it or simply copy the same key for all the node folders.
+
+handle_table_keys: false
+localhost_table_key_directory: "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/table_encryption_keys"
+table_key_directory: "/etc/scylla/table_encryption_keys"
+
 # If Scylla Manager will be used, set the following variables
 scylla_manager_enabled: true
 # deprecated in favour of below, it will be dropped soon, below should be used

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -274,6 +274,42 @@ scylla_ssl:
   client:
     enabled: true
 
+# Two types of encryption keys are available: System Keys and Table Keys.
+
+# System keys can be used for encrypting system data, like commit logs, batches and hints logs.
+# However, in the context of table keys (for encrypting sstables), if the user decides to use
+# a Replicated Key Provider, a system key will also be necessary for encrypting the encrypted_keys table,
+# where the replicated keys will be kept.
+# If you want to use this role for managing your system keys, regardless of them being used for system_info encryption
+# or for encrypting the encrypted_keys table, you should set {{ handle_system_keys }} to true and place all of your system
+# keys under the {{ localhost_system_key_directory }} folder. The role will copy all the local keys to the {{ system_key_directory }}
+# of every node.
+# Note that by default the {{ inventory_hostname }} is part of the localhost_system_key_directory. This allows you to define
+# different keys per host.
+# e.g.:
+# If your localhost_system_key_directory is set to "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/system_encryption_keys"
+# and you have the following file tree:
+#
+# ├── encryption_at_rest
+# │   ├── node1
+# │   │   └── system_encryption_keys
+# │   │       └── key1
+# │   ├── node2
+# │   │   └── system_encryption_keys
+# │   │       └── key2
+# │   └── node3
+# │       └── system_encryption_keys
+# │           └── key3
+# └── inventory.ini
+#
+# At the end of the process node1 will have key1, node2 will have key2 and node3 will have key3.
+# On the other hand, if you want to have the same keys for all the hosts you can define a {{ localhost_system_key_directory }}
+# without the {{ inventory_hostname }} in it or simply copy the same key for all the node folders.
+
+handle_system_keys: false
+localhost_system_key_directory: "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/system_encryption_keys"
+system_key_directory: "/etc/scylla/system_encryption_keys"
+
 # If Scylla Manager will be used, set the following variables
 scylla_manager_enabled: true
 # deprecated in favour of below, it will be dropped soon, below should be used

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -292,6 +292,13 @@
     - (scylla_ssl.internode.enabled|bool) or
       (scylla_ssl.client.enabled|bool)
 
+- name: Copy system keys
+  include_tasks: handle_encryption_at_rest_keys.yml
+  vars:
+    localhost_key_path: "{{ localhost_system_key_directory }}"
+    remote_key_path: "{{ system_key_directory }}"
+  when: handle_system_keys|bool
+
 # scylla_listen_address is a composite indirect value that depends on another per-host value - scylla_nic.
 # Therefore in order to be able to get the corresponding value via hostvars[item] later in the play we need to
 # have an actual value resolved.

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -299,6 +299,13 @@
     remote_key_path: "{{ system_key_directory }}"
   when: handle_system_keys|bool
 
+- name: Copy table keys
+  include_tasks: handle_encryption_at_rest_keys.yml
+  vars:
+    localhost_key_path: "{{ localhost_table_key_directory }}"
+    remote_key_path: "{{ table_key_directory }}"
+  when: handle_table_keys|bool
+
 # scylla_listen_address is a composite indirect value that depends on another per-host value - scylla_nic.
 # Therefore in order to be able to get the corresponding value via hostvars[item] later in the play we need to
 # have an actual value resolved.

--- a/ansible-scylla-node/tasks/handle_encryption_at_rest_keys.yml
+++ b/ansible-scylla-node/tasks/handle_encryption_at_rest_keys.yml
@@ -1,0 +1,50 @@
+---
+- name: Fail if localhost_key_path or remote_key_path vars are not defined
+  fail:
+    msg: "localhost_key_path and/or remote_key_path are not defined"
+  when: localhost_key_path is not defined or remote_key_path is not defined
+
+- name: Get stat for each one of the localhost keys
+  stat:
+    path: "{{ item }}"
+  register: _localhost_keys_stat
+  delegate_to: localhost
+  with_fileglob: "{{ localhost_key_path }}/*"
+
+# We only handle remote keys that have a local counterpart
+- name: Get stat for each one of the remote keys being tracked
+  stat:
+    path: "{{ remote_key_path }}/{{ item.stat.path | basename }}"
+  register: _remote_keys_stat
+  become: true
+  loop: "{{ _localhost_keys_stat.results }}"
+
+- name: Validate that the existing keys on remote and local hosts are the same
+  fail:
+    msg: "The file {{ item[1].stat.path }} is different from {{ item[0].stat.path }}"
+  when:
+    - item[1].stat.exists
+    - item[0].stat.path | basename == item[1].stat.path | basename
+    - item[0].stat.checksum != item[1].stat.checksum
+  with_nested:
+    - "{{ _localhost_keys_stat.results }}"
+    - "{{ _remote_keys_stat.results }}"
+
+- name: Create keys dir if it doesn't already exist
+  file:
+    path: "{{ remote_key_path }}"
+    state: directory
+    owner: scylla
+    group: scylla
+    mode: '700'
+  become: true
+
+- name: Copy key from localhost to all nodes
+  copy:
+    src: "{{ item.item }}"
+    dest: "{{ remote_key_path }}"
+    owner: scylla
+    group: scylla
+    mode: '600'
+  loop: "{{ _localhost_keys_stat.results }}"
+  become: true

--- a/ansible-scylla-node/templates/scylla.yaml.j2
+++ b/ansible-scylla-node/templates/scylla.yaml.j2
@@ -61,3 +61,6 @@ server_encryption_options:
     keyfile: {{ scylla_ssl.cert_path }}/{{ inventory_hostname }}.pem
     truststore: {{ scylla_ssl.cert_path }}/{{ scylla_cluster_name }}-ca.crt
 {% endif %}
+{% if handle_system_keys|bool %}
+system_key_directory: {{ system_key_directory }}
+{% endif %}

--- a/ansible-scylla-node/templates/scylla.yaml.j2
+++ b/ansible-scylla-node/templates/scylla.yaml.j2
@@ -64,3 +64,25 @@ server_encryption_options:
 {% if handle_system_keys|bool %}
 system_key_directory: {{ system_key_directory }}
 {% endif %}
+{% if system_info_encryption_local.enabled|bool %}
+system_info_encryption:
+    enabled: True
+    cipher_algorithm: {{ system_info_encryption_local.cipher_algorithm }}
+    secret_key_strength: {{ system_info_encryption_local.secret_key_strength }}
+    key_provider: LocalFileSystemKeyProviderFactory
+    secret_key_file: {{ system_info_encryption_local.secret_key_file }}
+{% elif system_info_encryption_kmip.enabled|bool %}
+system_info_encryption:
+    enabled: True
+    cipher_algorithm: {{ system_info_encryption_kmip.cipher_algorithm }}
+    secret_key_strength: {{ system_info_encryption_kmip.secret_key_strength }}
+    key_provider: KmipKeyProviderFactory
+    kmip_host: {{ system_info_encryption_kmip.kmip_host }}
+{% elif system_info_encryption_kms.enabled|bool %}
+system_info_encryption:
+    enabled: True
+    cipher_algorithm: {{ system_info_encryption_kms.cipher_algorithm }}
+    secret_key_strength: {{ system_info_encryption_kms.secret_key_strength }}
+    key_provider: KmsKeyProviderFactory
+    kms_host: {{ system_info_encryption_kms.kms_host }}
+{% endif %}


### PR DESCRIPTION
This PR adds the following features to the role:
* The ability of managing table keys and system keys
* The ability of enabling/disabling system encryption 

Note that enabling **data encryption** is not part of this PR and needs to be done manually by the user.

The following tests were executed:
* Validate that if `handle_system_keys` is set to `true`, any keys inside `localhost_system_key_directory` will be copied to `system_key_directory`
* Validate that if `handle_table_keys` is set to `true`, any keys inside `localhost_table_key_directory` will be copied to `table_key_directory`
* Validate that if any already existing key in the `system_key_directory` has a different content from a key with the same name in the `localhost_system_key_diretory`, the role will fail.
* Validate that if any existing key in the `table_key_directory` has a different content from a key with the same name in the `localhost_table_key_directory`, the role will fail.
* Validate that if `system_info_encryption_local.enabled` is set to `true`, the `scylla.yaml` file will be set appropriately
* Validate that if `system_info_encryption_kmip.enabled` is set to `true`, the `scylla.yaml` file will be set appropriately
* Validate that if `system_info_encryption_kms.enabled` is set to `true`, the `scylla.yaml` file will be set appropriately