### PR TITLE
scylla-node: don't ever install scylla on top of already installed one

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -200,6 +200,9 @@ scylla_version: '0.0.0'
 #scylla_edition: oss
 scylla_edition: enterprise
 
+# Set to true if you want to allow a Role to upgrade and already installed Scylla
+skip_installed_scylla_version_check: False
+
 scylla_snitch: GossipingPropertyFileSnitch
 
 # OPTIONAL: If GossipingPropertyFileSnitch in use, set this variable as per Scylla documentation

--- a/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
@@ -57,7 +57,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_deb_repos:
-          - "http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list"
+          - "http://downloads.scylladb.com/deb/ubuntu/scylla-2023.1.list"
         scylla_edition: "enterprise"
         scylla_version: "latest"
         scylla_io_probe: false

--- a/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
@@ -57,7 +57,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_deb_repos:
-          - "http://downloads.scylladb.com/deb/ubuntu/scylla-5.1.list"
+          - "http://downloads.scylladb.com/deb/ubuntu/scylla-5.2.list"
         scylla_edition: "oss"
         scylla_version: "latest"
         scylla_io_probe: false

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -74,10 +74,6 @@
       name: java
       path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-  - name: "Going to install {{ scylla_version }}"
-    set_fact:
-      scylla_version_to_install: "{{ scylla_version }}"
-
   - name: Install Scylla packages
     include_tasks: Debian_install.yml
   become: true

--- a/ansible-scylla-node/tasks/Debian_install.yml
+++ b/ansible-scylla-node/tasks/Debian_install.yml
@@ -21,6 +21,11 @@
         msg: "Too many/few choices for a requested version '{{ scylla_version_to_install }}': {{ aptversions.stdout_lines }}. Bailing out!"
       when: aptversions.stdout_lines | length != 1
 
+    - name: If Scylla is installed check if it's the same version as requested
+      fail:
+        msg: "Installed version ({{ installed_scylla_version }}) doesn't match a requested one ({{ aptversions.stdout }})"
+      when: scylla_is_installed and not skip_installed_scylla_version_check and installed_scylla_version != aptversions.stdout
+
     - name: Do install Scylla
       block:
         - name: Nuke a {{ scylla_edition }} pin file if exists
@@ -48,4 +53,5 @@
             name: "{{ scylla_package_prefix }}={{ aptversions.stdout }}"
             state: present
             allow_downgrade: yes
+      when: not scylla_is_installed
   become: true

--- a/ansible-scylla-node/tasks/Debian_install.yml
+++ b/ansible-scylla-node/tasks/Debian_install.yml
@@ -46,8 +46,9 @@
         # 'apt list -a' output has a package version as a second column and an arch as a third one.
         # Let's filter by the arch first and then cut the version column.
         # Then we will filter out all rows that start with a requested version string followed by a digit to filter out version like 2021.1.11 when 2021.1.1 was requested.
-        # And finally, we are going to get rid of duplications.
-        shell: apt list -a {{ scylla_package_prefix }} 2>/dev/null | grep `dpkg --print-architecture` | awk '{split($0,a," "); print a[2]}' | egrep -v "^{{ scylla_version_escaped }}[0123456789]+" | egrep "^{{ scylla_version_escaped }}" | sort | uniq
+        # Also filter our RCs which versions go like 2021.1.0~rcX.
+      # And finally, we are going to get rid of duplications.
+        shell: apt list -a {{ scylla_package_prefix }} 2>/dev/null | grep `dpkg --print-architecture` | awk '{split($0,a," "); print a[2]}' | egrep -v "^{{ scylla_version_escaped }}[0123456789~]+" | egrep "^{{ scylla_version_escaped }}" | sort | uniq
         register: aptversions
         vars:
           scylla_version_escaped: "{{ scylla_version_to_install | regex_escape }}"

--- a/ansible-scylla-node/tasks/Debian_install.yml
+++ b/ansible-scylla-node/tasks/Debian_install.yml
@@ -1,85 +1,51 @@
 ---
 # Requires a 'scylla_version_to_install' fact to be set to a version string we want to install
-- name: Install Scylla
+- name: Install Scylla version {{ scylla_version_to_install }}
   block:
-  - name: Install 'latest' Scylla
-    block:
-      - block:
-        - name: Nuke an OSS pin file if exists
-          file:
-            state: absent
-            path: /etc/apt/preferences.d/99-scylla
-
-        - name: Install latest OSS Scylla
-          apt:
-            name: scylla
-            state: latest
-        when: scylla_edition == 'oss'
-
-      - block:
-        - name: Nuke an Enterprise pin file if exists
-          file:
-            state: absent
-            path: /etc/apt/preferences.d/99-scylla-enterprise
-
-        - name: Install latest Enterprise Scylla
-          apt:
-            name: scylla-enterprise
-            state: latest
-        when: scylla_edition == 'enterprise'
-    when: scylla_version_to_install == 'latest'
-
-### Handle non-latest version installation
-  - name: Install explicitly specified Scylla version
-    block:
-      - name: Set Scylla package prefix as OSS
-        set_fact:
-          scylla_package_prefix: "scylla"
-        when: scylla_edition == 'oss'
-
-      - name: Set Scylla package prefix as Enterprise
-        set_fact:
-          scylla_package_prefix: "scylla-enterprise"
-        when: scylla_edition == 'enterprise'
-
-      - name: Get versions of {{ scylla_edition }} package
-        # 'apt list -a' output has a package version as a second column and an arch as a third one.
-        # Let's filter by the arch first and then cut the version column.
-        # Then we will filter out all rows that start with a requested version string followed by a digit to filter out version like 2021.1.11 when 2021.1.1 was requested.
-        # Also filter our RCs which versions go like 2021.1.0~rcX.
+    - name: Get versions of {{ scylla_edition }} package
+      # 'apt list -a' output has a package version as a second column and an arch as a third one.
+      # Let's filter by the arch first and then cut the version column.
+      # Then we will filter out all rows that start with a requested version string followed by a digit to filter out version like 2021.1.11 when 2021.1.1 was requested.
+      # Also filter our RCs which versions go like 2021.1.0~rcX.
       # And finally, we are going to get rid of duplications.
-        shell: apt list -a {{ scylla_package_prefix }} 2>/dev/null | grep `dpkg --print-architecture` | awk '{split($0,a," "); print a[2]}' | egrep -v "^{{ scylla_version_escaped }}[0123456789~]+" | egrep "^{{ scylla_version_escaped }}" | sort | uniq
-        register: aptversions
-        vars:
-          scylla_version_escaped: "{{ scylla_version_to_install | regex_escape }}"
+      shell: apt list -a {{ scylla_package_prefix }} 2>/dev/null | grep `dpkg --print-architecture` | awk '{split($0,a," "); print a[2]}' | egrep -v "^{{ scylla_version_escaped }}[0123456789~]+" | egrep "^{{ scylla_version_escaped }}" | sort | uniq
+      register: aptversions
+      vars:
+        scylla_version_escaped: "{{ scylla_version_to_install | regex_escape }}"
 
-        #  - debug:
-        #      msg: "{{ aptversions.stdout_line }}"
+      #  - debug:
+      #      msg: "{{ aptversions.stdout_line }}"
 
-      - name: "Validate scylla version correctness"
-        ansible.builtin.fail:
-          msg: "Too many/few choices for a requested version '{{ scylla_version_to_install }}': {{ aptversions.stdout_lines }}. Bailing out!"
-        when: aptversions.stdout_lines | length != 1
+    - name: "Validate scylla version correctness"
+      ansible.builtin.fail:
+        msg: "Too many/few choices for a requested version '{{ scylla_version_to_install }}': {{ aptversions.stdout_lines }}. Bailing out!"
+      when: aptversions.stdout_lines | length != 1
 
-      - name: Fetch version parts of Scylla package
-        set_fact:
-          scylla_version_split: "{{ aptversions.stdout | regex_findall(regexp, ignorecase=True) }}"
-        vars:
-          # All we know that the version is a string comprised of 3 parts separated by '-'
-          regexp: '^([^\-]+)-([^\-]+)-([^\-]+)$'
+    - name: Do install Scylla
+      block:
+        - name: Nuke a {{ scylla_edition }} pin file if exists
+          file:
+            state: absent
+            path: "/etc/apt/preferences.d/99-{{ scylla_package_prefix }}"
 
-      - name: Create package version pin file
-        template:
-          src: templates/apt-pin-file.j2
-          dest: "/etc/apt/preferences.d/99-{{ scylla_package_prefix }}"
-          owner: root
-          group: root
-          mode: '0644'
+        - name: Fetch version parts of Scylla package
+          set_fact:
+            scylla_version_split: "{{ aptversions.stdout | regex_findall(regexp, ignorecase=True) }}"
+          vars:
+            # All we know that the version is a string comprised of 3 parts separated by '-'
+            regexp: '^([^\-]+)-([^\-]+)-([^\-]+)$'
 
-      - name: "Install {{ aptversions.stdout }}"
-        apt:
-          name: "{{ scylla_package_prefix }}={{ aptversions.stdout }}"
-          state: present
-          allow_downgrade: yes
-    when: scylla_version_to_install != 'latest'
+        - name: Create package version pin file
+          template:
+            src: templates/apt-pin-file.j2
+            dest: "/etc/apt/preferences.d/99-{{ scylla_package_prefix }}"
+            owner: root
+            group: root
+            mode: '0644'
+
+        - name: "Install {{ aptversions.stdout }}"
+          apt:
+            name: "{{ scylla_package_prefix }}={{ aptversions.stdout }}"
+            state: present
+            allow_downgrade: yes
   become: true

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -84,32 +84,11 @@
 
 - name: Install Scylla
   block:
-  - name: Install latest OSS Scylla
+  - name: Install {{ scylla_edition }} Scylla
     yum:
-      name: scylla
-      state: latest
-      lock_timeout: 60
-    when: scylla_version == 'latest' and scylla_edition == 'oss'
-
-  - name: Install latest Enterprise Scylla
-    yum:
-      name: scylla-enterprise
-      state: latest
-    when: scylla_version == 'latest' and scylla_edition == 'enterprise'
-
-  - name: Install specified OSS Scylla
-    yum:
-      name: "scylla-{{ scylla_version }}"
+      name: "{{ scylla_package_prefix }}-{{ scylla_version_to_install }}"
       state: present
       lock_timeout: 60
-    when: scylla_version != 'latest' and scylla_edition == 'oss'
-
-  - name: Install specified Enterprise Scylla
-    yum:
-      name: "scylla-enterprise-{{ scylla_version }}"
-      state: present
-      lock_timeout: 60
-    when: scylla_version != 'latest' and scylla_edition == 'enterprise'
   become: true
 
 - name: Configure SELinux

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -82,6 +82,23 @@
   when: item.split(".")[-1] == "repo"
   become: true
 
+- name: If Scylla is installed check if it's the same version as requested
+  block:
+    - name: Check if {{ scylla_package_prefix }} {{ scylla_version_to_install }} is installed
+      yum:
+        name: "{{ scylla_package_prefix }}-{{ scylla_version_to_install }}"
+        state: installed
+        lock_timeout: 60
+      check_mode: true
+      register: result
+      become: true
+
+    - name: Validate the result
+      fail:
+        msg: "Installed version ({{ installed_scylla_version }}) doesn't match a requested one ({{ scylla_version_to_install }})"
+      when: result.changed
+  when: scylla_is_installed and not skip_installed_scylla_version_check
+
 - name: Install Scylla
   block:
   - name: Install {{ scylla_edition }} Scylla
@@ -90,6 +107,7 @@
       state: present
       lock_timeout: 60
   become: true
+  when: not scylla_is_installed
 
 - name: Configure SELinux
   shell: |

--- a/ansible-scylla-node/tasks/main.yml
+++ b/ansible-scylla-node/tasks/main.yml
@@ -8,6 +8,52 @@
   package_facts:
     manager: auto
 
+- name: Set Scylla package prefix as OSS
+  set_fact:
+    scylla_package_prefix: "scylla"
+  when: scylla_edition == 'oss'
+
+- name: Set Scylla package prefix as Enterprise
+  set_fact:
+    scylla_package_prefix: "scylla-enterprise"
+  when: scylla_edition == 'enterprise'
+
+- name: Check if {{ scylla_package_prefix }} meta-package is installed
+  set_fact:
+    scylla_is_installed: "{{ true if scylla_package_prefix in ansible_facts.packages else false }}"
+
+- name: Get installed scylla version
+  set_fact:
+    installed_scylla_version: "{{ ansible_facts.packages[scylla_package_prefix][0]['version'] }}"
+  when: scylla_is_installed
+
+- name: Initialize scylla_version_to_install to {{ scylla_version }}
+  set_fact:
+    scylla_version_to_install: "{{ scylla_version }}"
+
+- name: Get latest Scylla {{ scylla_package_prefix }} version if needed
+  block:
+    - name: Set latest Scylla version URL optional parameter for Scylla Enterprise version
+      set_fact:
+        scylla_latest_version_url_parameter: "{{ '?system=enterprise' if scylla_edition == 'enterprise' else '' }}"
+
+    - name: Get {{ scylla_package_prefix }} latest version
+      ansible.builtin.uri:
+        url: "https://repositories.scylladb.com/scylla/check_version{{ scylla_latest_version_url_parameter }}"
+        method: GET
+        return_content: true
+      register: scylla_latest_version
+
+    - name: Set scylla_version_to_install to {{ scylla_latest_version.json['version'] }}
+      set_fact:
+        scylla_version_to_install: "{{ scylla_latest_version.json['version'] }}"
+  when: scylla_version == 'latest' and install_type == 'online'
+
+- name: "Sanity check: latest version requires online installation type"
+  fail:
+    msg: "Latest Scylla version can only be installed with an 'online' installation"
+  when: scylla_version == 'latest' and install_type != 'online'
+
 # Upgrade
 - name: Upgrade Scylla
   include_tasks: upgrade/main.yml


### PR DESCRIPTION
Scylla should only be upgraded via the corresponding 'upgrade' flow. Other than that the Role should only install binaries if they haven't been installed yet.

If they have already been installed but the version differs from the one specified via 'scylla_version' Role will error out by default.

The Operator may decide to skip the check above using 'skip_installed_scylla_version_check'.