### PR TITLE
rolling_*_upgrade: Adds skip_installed_scylla_version_check

### DIFF
--- a/example-playbooks/rolling_ops/rolling_major_upgrade.yml
+++ b/example-playbooks/rolling_ops/rolling_major_upgrade.yml
@@ -8,6 +8,7 @@
   vars:
     - upgrade_version: true
     - upgrade_major: true
+    - skip_installed_scylla_version_check: true
 #    - scylla_edition: enterprise
 #    - scylla_version: latest
 

--- a/example-playbooks/rolling_ops/rolling_minor_upgrade.yml
+++ b/example-playbooks/rolling_ops/rolling_minor_upgrade.yml
@@ -8,6 +8,7 @@
   vars:
     - upgrade_version: true
     - upgrade_major: false
+    - skip_installed_scylla_version_check: true
 #    - scylla_edition: enterprise
 #    - scylla_version: latest
 


### PR DESCRIPTION
Sets skip_installed_scylla_version_check to true, otherwise the playbook won't be able to run the required upgrade