### PR TITLE
ansible-scylla-node: Allows Scylla to be installed when an upgrade is…

### DIFF
--- a/ansible-scylla-node/tasks/Debian_install.yml
+++ b/ansible-scylla-node/tasks/Debian_install.yml
@@ -53,5 +53,5 @@
             name: "{{ scylla_package_prefix }}={{ aptversions.stdout }}"
             state: present
             allow_downgrade: yes
-      when: not scylla_is_installed
+      when: not scylla_is_installed or upgrade_scylla
   become: true

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -107,7 +107,7 @@
       state: present
       lock_timeout: 60
   become: true
-  when: not scylla_is_installed
+  when: not scylla_is_installed or upgrade_scylla
 
 - name: Configure SELinux
   shell: |


### PR DESCRIPTION
… required

This patch will also allow Scylla to be installed if upgrade_version is set to true.