### PR TITLE
ansible-scylla-node: Replaces upgrade_scylla variable

### DIFF
--- a/ansible-scylla-node/tasks/Debian_install.yml
+++ b/ansible-scylla-node/tasks/Debian_install.yml
@@ -53,5 +53,5 @@
             name: "{{ scylla_package_prefix }}={{ aptversions.stdout }}"
             state: present
             allow_downgrade: yes
-      when: not scylla_is_installed or upgrade_scylla
+      when: not scylla_is_installed or upgrade_version
   become: true


### PR DESCRIPTION
This variable must be called upgrade_version as it was specified in the corresponding commit.