### PR TITLE
extra-playbooks: add a playbook that prints a CPUSET value

### DIFF
--- a/extra-playbooks/get_scylla_cpuset.yml
+++ b/extra-playbooks/get_scylla_cpuset.yml
@@ -1,0 +1,14 @@
+---
+
+- hosts: scylla
+  gather_facts: no
+  tasks:
+    - name: Get CPUSET
+      shell: |
+        grep CPUSET /etc/scylla.d/cpuset.conf | grep -v ^# | cut -d" " -f2 | cut -d"\"" -f1
+      run_once: true
+      register: _scylla_cpuset
+
+    - name: Show the version
+      debug:
+        var: _scylla_cpuset.stdout


### PR DESCRIPTION
This playbook prints a CPUSET value from cpuset.conf on the first node from the inventory section "scylla".