### PR TITLE
ansible-scylla-node: Adds 2023.1 to the version matrix

### DIFF
--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -16,13 +16,13 @@
           minimum_version: '8.0',
           template: 'redhat',
           oss: ['4.4','4.3','4.2','4.1'],
-          enterprise: ['2022.2','2021.1','2020.1']
+          enterprise: ['2023.1','2022.2','2021.1','2020.1']
         },
         '7': {
           minimum_version: '7.3',
           template: 'redhat',
           oss: ['4.4','4.3','4.2','4.1','4.0'],
-          enterprise: ['2022.2','2021.1','2020.1']
+          enterprise: ['2023.1','2022.2','2021.1','2020.1']
         }
       },
       # Debian
@@ -31,7 +31,7 @@
           minimum_version: '10',
           template: 'debian',
           oss: ['4.4','4.3','4.2','4.1'],
-          enterprise: ['2022.2','2022.1','2021.1','2020.1']
+          enterprise: ['2023.1','2022.2','2022.1','2021.1','2020.1']
         },
         '9': {
           minimum_version: '9',
@@ -46,7 +46,7 @@
           minimum_version: '20.04',
           template: 'ubuntu',
           oss: ['4.4','4.3'],
-          enterprise: ['2022.2','2022.1','2021.1']
+          enterprise: ['2023.1','2022.2','2022.1','2021.1']
         },
         '18': {
           minimum_version: '18.04',


### PR DESCRIPTION
Adds 2023.1 version to the existing operating systems of the support matrix