### PR TITLE
ansible-scylla-node: Adds Ubuntu 22.04 to the support matrix

### DIFF
--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -42,6 +42,12 @@
       },
       # Ubuntu
       ubuntu: {
+        '22': {
+          minimum_version: '22.04',
+          template: 'ubuntu',
+          oss: ['5.2','5.1','5.0'],
+          enterprise: ['2023.1','2022.2','2022.1','2021.1']
+        },
         '20': {
           minimum_version: '20.04',
           template: 'ubuntu',


### PR DESCRIPTION
This patch adds support for Ubuntu 22.04 based on https://opensource.docs.scylladb.com/stable/getting-started/os-support.html