### PR TITLE
rule_config.yml.j2: revert the severity workaround

### DIFF
--- a/ansible-scylla-monitoring/templates/rule_config.yml.j2
+++ b/ansible-scylla-monitoring/templates/rule_config.yml.j2
@@ -56,7 +56,7 @@ route:
       severity: "3"
     receiver: team-X-mails-urgent
   - match:
-      severity: "info"
+      severity: "error"
     receiver: team-X-mails-urgent
   - match:
       severity: "warn"


### PR DESCRIPTION
"prometheus.rules.yml: re-map the number to level alerts" patch is present in Scylla Monitoring 4.4.5 and later.

We can revert the workaround now.

Reverts 9653157222dd30c879bb34aabd1011527d2b11d1