### PR TITLE
rule_config.yml.j2: fix a mistake in severity mapping

### DIFF
--- a/ansible-scylla-monitoring/templates/rule_config.yml.j2
+++ b/ansible-scylla-monitoring/templates/rule_config.yml.j2
@@ -59,5 +59,5 @@ route:
       severity: "error"
     receiver: team-X-mails-urgent
   - match:
-      severity: "warn"
+      severity: "critical"
     receiver: team-X-mails-urgent


### PR DESCRIPTION
"3" corresponds to "error"
"4" - to "critical"

So, we want to create an URGENT email for "error" and "critical" (not "warn").