### PR TITLE
Revert "ansible-scylla-monitoring: Updates SMTP server used by default"

### DIFF
--- a/ansible-scylla-monitoring/templates/rule_config.yml.j2
+++ b/ansible-scylla-monitoring/templates/rule_config.yml.j2
@@ -55,7 +55,7 @@ receivers:
   email_configs:
   - to: {{ alerts_receiver_email }}
     from: {{ alerts_sender_email }}
-    smarthost: smtp-relay.gmail.com:587
+    smarthost: smtp.gmail.com:587
     auth_username: {{ alerts_sender_email }}
     auth_identity: {{ alerts_sender_email }}
     auth_password: {{ alerts_sender_password }}


### PR DESCRIPTION
This reverts commit c84fb789df3d18d7478f23cb9214fc09481bc119.