### PR TITLE
molecule: Set force_schema_commit_log to true

### DIFF
--- a/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
@@ -78,6 +78,9 @@ provisioner:
 #        skip_ntp: True
         skip_swap: True
         scylla_manager_deb_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-bionic.list"
+        scylla_yaml_params:
+          force_schema_commit_log: true
+          consistent_cluster_management: true
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml


### PR DESCRIPTION
In the latest OSS version (5.4.0), if we use the defaults from Scylla we'll see the following error:
`init - Bad configuration: consistent_cluster_management requires schema commit log to be enabled`

This happens because consistent_cluster_management is set to true and force_schema_commit_log is set to false by default.

This PR fixes this error in our CI by setting force_schema_commit_log to true in scylla_yaml_params.