### PR TITLE
rule_config.yml.j2: include the alert name and severity in the subject

### DIFF
--- a/ansible-scylla-monitoring/templates/rule_config.yml.j2
+++ b/ansible-scylla-monitoring/templates/rule_config.yml.j2
@@ -50,7 +50,7 @@ receivers:
     auth_password: {{ alerts_sender_password }}
     send_resolved: false
     headers:
-      Subject: '[PRODUCTION] NORMAL Managed-Services - Cluster:{{ scylla_cluster_name }}'
+      Subject: '[PRODUCTION] {{ '{{ .CommonLabels.alertname }}' }} {{ '{{ .CommonLabels.severity }}' }}: NORMAL Managed-Services - Cluster:{{ scylla_cluster_name }}'
 - name: team-X-mails-urgent
   email_configs:
   - to: {{ alerts_receiver_email }}
@@ -61,9 +61,9 @@ receivers:
     auth_password: {{ alerts_sender_password }}
     send_resolved: false
     headers:
-      Subject: '[PRODUCTION] URGENT Managed-Services - Cluster:{{ scylla_cluster_name }}'
+      Subject: '[PRODUCTION] {{ '{{ .CommonLabels.alertname }}' }} {{ '{{ .CommonLabels.severity }}' }}: URGENT Managed-Services - Cluster:{{ scylla_cluster_name }}'
 route:
-  group_by: ['severity']
+  group_by: [alertname, 'severity']
   group_interval: 5m
   group_wait: 30s
   repeat_interval: 6h


### PR DESCRIPTION
Aggregate by an alert name and the severity (before that was only by severity) and then include both an alert name and its severity in the corresponding email subject.

As a result for tooManyFiles alert with a 'warn' severity a subject is going to look like this:

[PRODUCTION] tooManyFiles warn: URGENT Managed-Services - Cluster:cluster-name-goes-here