### PR TITLE
ansible-scylla-node: Add default scylla_seeds back

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -242,6 +242,10 @@ always_replace_io_properties: False
 
 io_conf: 'SEASTAR_IO="--io-properties-file /etc/scylla.d/io_properties.yaml"'
 
+# Seeds node list
+scylla_seeds:
+  - "{{ groups['scylla'][0] }}"
+
 scylla_listen_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 scylla_rpc_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 scylla_broadcast_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"


### PR DESCRIPTION
This variable was removed by mistake in e42ec43