### PR TITLE
Node/Loader Roles: Debian.yml: remove explicit update-java-alternatives call

### DIFF
--- a/ansible-scylla-loader/tasks/Debian.yml
+++ b/ansible-scylla-loader/tasks/Debian.yml
@@ -57,12 +57,6 @@
     force_apt_get: yes
   become: true
 
-- name: Correct java version selected
-  alternatives:
-    name: java
-    path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-  become: true
-
 - name: install scylla-tools-core|scylla-enterprise-tools-core
   block:
     - package:

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -69,11 +69,6 @@
       state: present
       force_apt_get: yes
 
-  - name: Correct java version selected
-    alternatives:
-      name: java
-      path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-
   - name: Install Scylla packages
     include_tasks: Debian_install.yml
   become: true


### PR DESCRIPTION
There is no need to call update-java-alternatives explicitly since openjdk-8-jre-headless .deb package invokes it as a post-install action.

Tested on Ubuntu 20.04 on both x86 and on arm64 HW.

Fixes #325