### PR TITLE
ansible-scylla-node: Enforces the installation of each APT key set

### DIFF
--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -8,6 +8,19 @@
       update_cache: yes
     when: install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)
 
+  - name: "Purge keyring '{{ scylla_repo_keyringfile }}'"
+    ansible.builtin.file:
+      path: "{{ scylla_repo_keyringfile }}"
+      state: absent
+    when: install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)
+
+  - name: Remove an apt key by id previously added
+    ansible.builtin.apt_key:
+      id: "{{ item }}"
+      state: absent
+    with_items: "{{ scylla_repo_keys }}"
+    when: install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)
+
   - name: Add an apt key by id from a keyserver
     apt_key:
       keyserver: "{{ scylla_repo_keyserver }}"


### PR DESCRIPTION
Before this patch, if a key with a specific ID already installed was updated (because it was expired, for example), the key won't be locally updated causing and APT failure.

This patch ensures the usage of the latest apt key available.