### PR TITLE
ansible-scylla-node: Update gpg keys before running apt update

### DIFF
--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -1,25 +1,25 @@
 ---
 - name: Add Scylla repos
   block:
-  - name: Install gnupg2 dependency
-    apt:
-      name: "gnupg2"
-      state: present
-      update_cache: yes
-    when: install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)
-
   - name: "Purge keyring '{{ scylla_repo_keyringfile }}'"
     ansible.builtin.file:
       path: "{{ scylla_repo_keyringfile }}"
       state: absent
-    when: install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)
+    when: "'gnupg2' in ansible_facts.packages and install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)"
 
   - name: Remove an apt key by id previously added
     ansible.builtin.apt_key:
       id: "{{ item }}"
       state: absent
     with_items: "{{ scylla_repo_keys }}"
-    when: install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)
+    when: "'gnupg2' in ansible_facts.packages and install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)"
+
+  - name: Install gnupg2 dependency if it's not already installed
+    apt:
+      name: "gnupg2"
+      state: present
+      update_cache: yes
+    when: "'gnupg2' not in ansible_facts.packages and install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)"
 
   - name: Add an apt key by id from a keyserver
     apt_key:


### PR DESCRIPTION
The task installing gnupg2 runs the equivalent to `apt update` before moving forward
due to `update_cache` being set to `true`. However if this role is being executed for
an old cluster which has an expired key, the `apt update` will fail.
In order to prevent that, this patch does the following:
  * Removes keyring file only if gnupg2 is already installed
  * Removes scylla repo keys only if gnupg2 is already installed
  * Installs gnupg2 only if it's not installed before setting up the keys