### PR TITLE
ansible-scylla-node: Prevents APT to be updated when gnupg2 is installed

### DIFF
--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -5,7 +5,6 @@
     apt:
       name: "gnupg2"
       state: present
-      update_cache: yes
     when: install_type == 'online' and scylla_repo_keyserver is defined and scylla_repo_keys is defined and (scylla_repo_keys|length > 0)
 
   - name: "Purge keyring '{{ scylla_repo_keyringfile }}'"


### PR DESCRIPTION
If by any chance the GPG signature is expired, it won't allow the role to install gnupg2 because "update_cache" will force APT to update its cache.