### PR TITLE
ansible-scylla-node: Remove run_once from io_properties block and fix CI

### DIFF
--- a/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
@@ -78,6 +78,9 @@ provisioner:
 #        skip_ntp: True
         skip_swap: True
         scylla_manager_deb_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-bionic.list"
+        scylla_yaml_params:
+          force_schema_commit_log: true
+          consistent_cluster_management: true
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -82,7 +82,6 @@
     - set_fact:
         io_conf: "{{ _io_conf.stdout_lines[0] }}"
   when: io_properties is not defined and scylla_io_probe|bool == True and (scylla_io_probe_dc_aware|bool == False or dc_to_node_list[dc][0] == inventory_hostname)
-  run_once: "{{ not scylla_io_probe_dc_aware|bool }}"
   become: true
 
 - name: For every node, check if io.conf already exists and if it's not empty


### PR DESCRIPTION
Assuming `scylla_io_probe == true`, this `run_once` had the following logic:
  * If `scylla_io_probe_dc_aware` was false, the block would run only once and copy the io_properties from the first node to all the others
  * If it was true the block would run for all the hosts

However, having `scylla_io_probe_dc_aware` set to false means that we don't know if the nodes configuration will be the same, meaning that we'd rather measure io_properties per node than copy it from the first node.

This PR fixes this problem by removing the `run_once`.

Now, we'll only copy io_properties to other nodes in the following scenarios:
  * if both, `scylla_io_probe` and `scylla_io_probe_dc_aware` are set to `true`, then we copy the io_properties from the first node of each DC to all the others of the same DC.
  * if io_properties is explicitly set via ansible params, its value will be copied to the nodes of all DCs.