### PR TITLE
scylla-node: use rpc_address instead of listen_address on wait CQL port to be up

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -314,6 +314,11 @@
     listen_address: "{{ scylla_listen_address }}"
 
 # The same relates to the below
+- name: Resolve scylla_rpc_address
+  set_fact:
+    rpc_address: "{{ scylla_rpc_address }}"
+
+# The same relates to the below
 - name: Resolve scylla_broadcast_address
   set_fact:
     broadcast_address: "{{ scylla_broadcast_address }}"

--- a/ansible-scylla-node/tasks/generate_tokens.yml
+++ b/ansible-scylla-node/tasks/generate_tokens.yml
@@ -2,7 +2,7 @@
 - name: Find the first node which is already bootstrapped, if any
   wait_for:
     port: 9042
-    host: "{{ hostvars[item]['listen_address'] }}"
+    host: "{{ hostvars[item]['rpc_address'] }}"
     timeout: 5
   register: wait_for_cql_port_output
   ignore_errors: true

--- a/ansible-scylla-node/tasks/start_one_node.yml
+++ b/ansible-scylla-node/tasks/start_one_node.yml
@@ -7,9 +7,9 @@
   delegate_to: "{{ item }}"
 
 # By default waits at most 7 hours for a node to start - bootstrapping and the corresponding streaming can take quite long
-- name: Wait for CQL port on {{ hostvars[item]['listen_address'] }}
+- name: Wait for CQL port on {{ hostvars[item]['rpc_address'] }}
   wait_for:
     port: 9042
-    host: "{{ hostvars[item]['listen_address'] }}"
+    host: "{{ hostvars[item]['rpc_address'] }}"
     timeout: "{{ scylla_bootstrap_wait_time_sec }}"
   delegate_to: "{{ item }}"


### PR DESCRIPTION
Hello,

I recently wanted to deploy a scylladb cluster with this playbook, I encountered a small problem when I redefined the scylla_rpc_address varriable to specific IP, the start_one_node task waits for scylla to be up on the wrong address (listen_address) and never succeeds.