### PR TITLE
scylla-node: fix scylla_setup call

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -147,7 +147,7 @@
 
 - name: configure Scylla
   shell: |
-    scylla_setup --no-raid-setup --no-ec2-check --no-kernel-check --no-ntp-setup --no-io-setup --no-node-exporter --no-coredump-setup --no-sysconfig-setup --no-swap-setup --no-cpuscaling-setup --no-fstrim-setup
+    scylla_setup --no-raid-setup --no-ec2-check --no-kernel-check --no-ntp-setup --no-io-setup --no-node-exporter --no-coredump-setup --no-sysconfig-setup --no-swap-setup --no-cpuscaling-setup --no-fstrim-setup --no-memory-setup
   become: true
 
 - name: configure scylla.yaml

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -147,9 +147,8 @@
 
 - name: configure Scylla
   shell: |
-    scylla_setup --no-raid-setup --nic {{ scylla_nic }} --setup-nic-and-disks --no-ec2-check --no-kernel-check --no-ntp-setup --no-io-setup --no-node-exporter --no-coredump-setup --no-sysconfig-setup --no-swap-setup
+    scylla_setup --no-raid-setup --no-ec2-check --no-kernel-check --no-ntp-setup --no-io-setup --no-node-exporter --no-coredump-setup --no-sysconfig-setup --no-swap-setup --no-cpuscaling-setup --no-fstrim-setup
   become: true
-  when: ansible_facts.services["scylla-server.service"] is defined and ansible_facts.services["scylla-server.service"]["state"] != "running"
 
 - name: configure scylla.yaml
   template:


### PR DESCRIPTION
Add missing --no-cpuscaling-setup and --no-fstrim-setup (we explicitly setup these later in the play) and make sure to always call `scylla_setup` - with the parameters we call it it should be safe to call it even when scylla server is already running.

We also don't need to give '--nic {{ scylla_nic }} --setup-nic-and-disks' parameters because they are canceled by --no-sysconfig-setup at the end of the command line and because we are going to call scylla_sysconfig_setup later in the play explicitly.

Fixes #339