### PR TITLE
scylla-manager: update existing cluster with provided metadata

### DIFF
--- a/ansible-scylla-manager/tasks/add-clusters.yml
+++ b/ansible-scylla-manager/tasks/add-clusters.yml
@@ -12,10 +12,9 @@
   shell: |
     sctool cluster add \
       --host {{ item.host }} \
-      --auth-token "{{ auth_token }}" \
       --name {{ item.cluster_name }} \
-      {% if item.without_token is defined and item.without_token|bool == true %}
-      --without_token \
+      {% if not item.without_token is defined or item.without_token|bool == false %}
+      --auth-token "{{ auth_token }}" \
       {% endif %}
       {% if item.username is defined and item.password is defined %}
       --username {{ item.username }} \

--- a/ansible-scylla-manager/tasks/add-clusters.yml
+++ b/ansible-scylla-manager/tasks/add-clusters.yml
@@ -22,3 +22,17 @@
       --password {{ item.password }} \
       {% endif %}
   when: cluster_already_added is not defined or cluster_already_added.stdout != "present"
+
+- name: Enforce configuration for existing cluster "{{ item.cluster_name }}"
+  shell: |
+    sctool cluster update -c {{ item.cluster_name }}  \
+      --host {{ item.host }} \
+      {% if not item.without_token is defined or item.without_token|bool == false %} \
+      --auth-token "{{ auth_token }}" \
+      {% endif %}
+      {% if item.username is defined and item.password is defined %}
+      --username {{ item.username }} \
+      --password {{ item.password }} \
+      {% endif %}
+  when: cluster_already_added is defined and cluster_already_added.stdout == "present"
+      


### PR DESCRIPTION
Allow updating existing clusters with a new metadata. Before this patch if the cluster is already added to SM via 'sctool cluster add' there was not way to update its configuration via Manager Role.