### PR TITLE
all-roles: use HTTPS for accessing downloads.scylladb.com

### DIFF
--- a/ansible-scylla-manager/README.md
+++ b/ansible-scylla-manager/README.md
@@ -32,11 +32,11 @@ Example Playbook
         host: "{{ groups['scylla'][0]}}"
         auth_token_file: scyllamgr_auth_token.txt
         without_repair: false
-    scylla_manager_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list"
+    scylla_manager_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list"
     #  These will be passed on to the ansible-scylla-node role applied to the Manager node in order to deploy a local Scylla instance
     scylla_manager_db_vars:
       scylla_repos:
-        - 'http://repositories.scylladb.com/scylla/repo/../ubuntu/scylladb-4.1-bionic.list'
+        - 'https://repositories.scylladb.com/scylla/repo/../ubuntu/scylladb-4.1-bionic.list'
       # Only for Ubuntu/Debian
       scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
       scylla_repo_keys:

--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -3,9 +3,9 @@
 
 # Repo URL for the Manager
 # deprecated in favour of below, it will be dropped soon, below should be used
-scylla_manager_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
+scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
 
-scylla_manager_deb_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
 scylla_manager_rpm_repo_url: "{{ scylla_manager_repo_url }}"
 
 scylla_manager_db_vars:

--- a/ansible-scylla-node/README.md
+++ b/ansible-scylla-node/README.md
@@ -45,7 +45,7 @@ Example Playbook
 
     # variables for the Scylla node role (can be set here or in the role's vars/main.yml)
     scylla_repos:
-      - 'http://repositories.scylladb.com/scylla/repo/613b5a39-91d7-4267-aa15-4384fde87442/ubuntu/scylladb-4.1-bionic.list'
+      - 'https://repositories.scylladb.com/scylla/repo/613b5a39-91d7-4267-aa15-4384fde87442/ubuntu/scylladb-4.1-bionic.list'
     scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
     scylla_repo_keys:
       - 5e08fbd8b5d6ec9c
@@ -66,7 +66,7 @@ Example Playbook
     scylla_api_address: '127.0.0.1'
     scylla_api_port: '10000'
     scylla_manager_enabled: true
-    scylla_manager_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list"
+    scylla_manager_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list"
 
   tasks:
     # Workaround for some Debian versions that might not have XFS support out of the box

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -104,12 +104,12 @@ firewall_enabled: false
 # URL of an RPM .repo file or a DEB .list file
 # deprecated in favour of below, it will be dropped soon, below should be used
 #scylla_repos:
-#  - http://downloads.scylladb.com/rpm/centos/scylla-2021.1.repo
+#  - https://downloads.scylladb.com/rpm/centos/scylla-2021.1.repo
 #
 # Both scylla_deb_repos and scylla_rpm_repos, if undefined, would resolve to a URL that corresponds
 # to a scylla version to which scylla_version resolves to.
 #scylla_deb_repos:
-#  - http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list
+#  - https://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list
 #
 #scylla_rpm_repos: "{{ scylla_repos }}"
 
@@ -392,9 +392,9 @@ system_info_encryption_kms:
 # If Scylla Manager will be used, set the following variables
 scylla_manager_enabled: true
 # deprecated in favour of below, it will be dropped soon, below should be used
-scylla_manager_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
+scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
 
-scylla_manager_deb_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
 scylla_manager_rpm_repo_url: "{{ scylla_manager_repo_url }}"
 
 scylla_manager_agent_upgrade: true

--- a/ansible-scylla-node/molecule/centos7/molecule.yml
+++ b/ansible-scylla-node/molecule/centos7/molecule.yml
@@ -44,7 +44,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_repos:
-          - "http://repositories.scylladb.com/scylla/repo/4a57aebd-c6ac-46e9-8030-bdcf5a51ee0e/centos/scylladb-4.4.repo"
+          - "https://repositories.scylladb.com/scylla/repo/4a57aebd-c6ac-46e9-8030-bdcf5a51ee0e/centos/scylladb-4.4.repo"
         scylla_edition: "oss"
         scylla_io_probe: false
         io_properties:
@@ -56,7 +56,7 @@ provisioner:
               write_bandwidth: 1000
         dc: "test_dc"
         rack: "test_rack"
-        scylla_manager_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo"
+        scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo"
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/molecule/centos8/molecule.yml
+++ b/ansible-scylla-node/molecule/centos8/molecule.yml
@@ -64,7 +64,7 @@ provisioner:
         skip_cpuset: True
         skip_selinux: True
         skip_ntp: True
-        scylla_manager_rpm_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
+        scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/molecule/debian10/molecule.yml
+++ b/ansible-scylla-node/molecule/debian10/molecule.yml
@@ -44,7 +44,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_repos:
-          - "http://repositories.scylladb.com/scylla/repo/deb/debian/scylladb-4.4-buster.list"
+          - "https://repositories.scylladb.com/scylla/repo/deb/debian/scylladb-4.4-buster.list"
         scylla_edition: "oss"
         scylla_io_probe: false
         io_properties:
@@ -56,7 +56,7 @@ provisioner:
               write_bandwidth: 1000
         dc: "test_dc"
         rack: "test_rack"
-        scylla_manager_repo_url: "http://downloads.scylladb.com/deb/debian/scylladb-manager-2.3-stretch.list"
+        scylla_manager_repo_url: "https://downloads.scylladb.com/deb/debian/scylladb-manager-2.3-stretch.list"
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/molecule/debian9/molecule.yml
+++ b/ansible-scylla-node/molecule/debian9/molecule.yml
@@ -44,7 +44,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_repos:
-          - "http://repositories.scylladb.com/scylla/repo/deb/debian/scylladb-4.4-stretch.list"
+          - "https://repositories.scylladb.com/scylla/repo/deb/debian/scylladb-4.4-stretch.list"
         scylla_edition: "oss"
         scylla_io_probe: false
         io_properties:
@@ -56,7 +56,7 @@ provisioner:
               write_bandwidth: 1000
         dc: "test_dc"
         rack: "test_rack"
-        scylla_manager_repo_url: "http://downloads.scylladb.com/deb/debian/scylladb-manager-2.3-stretch.list"
+        scylla_manager_repo_url: "https://downloads.scylladb.com/deb/debian/scylladb-manager-2.3-stretch.list"
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/molecule/fedora/molecule.yml
+++ b/ansible-scylla-node/molecule/fedora/molecule.yml
@@ -44,7 +44,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_repos:
-          - "http://repositories.scylladb.com/scylla/repo/4a57aebd-c6ac-46e9-8030-bdcf5a51ee0e/centos/scylladb-4.4.repo"
+          - "https://repositories.scylladb.com/scylla/repo/4a57aebd-c6ac-46e9-8030-bdcf5a51ee0e/centos/scylladb-4.4.repo"
         scylla_edition: "oss"
         scylla_io_probe: false
         io_properties:
@@ -56,7 +56,7 @@ provisioner:
               write_bandwidth: 1000
         dc: "test_dc"
         rack: "test_rack"
-        scylla_manager_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo"
+        scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo"
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/molecule/ubuntu1604/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu1604/molecule.yml
@@ -44,7 +44,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_repos:
-          - "http://downloads.scylladb.com/deb/ubuntu/scylla-4.4-xenial.list"
+          - "https://downloads.scylladb.com/deb/ubuntu/scylla-4.4-xenial.list"
         scylla_edition: "oss"
         scylla_io_probe: false
         io_properties:
@@ -56,7 +56,7 @@ provisioner:
               write_bandwidth: 1000
         dc: "test_dc"
         rack: "test_rack"
-        scylla_manager_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.3-xenial.list"
+        scylla_manager_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.3-xenial.list"
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/molecule/ubuntu1804/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu1804/molecule.yml
@@ -43,7 +43,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_deb_repos:
-          - "http://downloads.scylladb.com/deb/ubuntu/scylla-4.6-bionic.list"
+          - "https://downloads.scylladb.com/deb/ubuntu/scylla-4.6-bionic.list"
         scylla_edition: "oss"
         scylla_io_probe: false
         io_properties:
@@ -60,7 +60,7 @@ provisioner:
         skip_coredump: True
         skip_sysconfig: True
         skip_cpuset: True
-        scylla_manager_deb_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-bionic.list"
+        scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-bionic.list"
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml

--- a/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
@@ -78,7 +78,7 @@ provisioner:
         #devmode: True
 #        skip_ntp: True
         skip_swap: True
-        scylla_manager_deb_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.2.list"
+        scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.2.list"
         scylla_yaml_params:
           force_schema_commit_log: true
           consistent_cluster_management: true

--- a/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004/molecule.yml
@@ -78,7 +78,7 @@ provisioner:
         # devmode: True
 #        skip_ntp: True
         skip_swap: True
-        scylla_manager_deb_repo_url: "http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.2.list"
+        scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.2.list"
         scylla_yaml_params:
           force_schema_commit_log: true
           consistent_cluster_management: true

--- a/ansible-scylla-node/tasks/set_default_repo.yml
+++ b/ansible-scylla-node/tasks/set_default_repo.yml
@@ -12,7 +12,7 @@
   block:
     - name: Set temporary fact
       set_fact:
-        _scylla_repo_default: "http://downloads.scylladb.com/deb/ubuntu/scylla-{{ _split_version[0] }}.{{ _split_version[1] }}.list"
+        _scylla_repo_default: "https://downloads.scylladb.com/deb/ubuntu/scylla-{{ _split_version[0] }}.{{ _split_version[1] }}.list"
 
     - name: Set scylla_deb_repos
       set_fact:
@@ -23,7 +23,7 @@
   block:
     - name: Set temporary fact
       set_fact:
-        _scylla_repo_default: "http://downloads.scylladb.com/rpm/centos/scylla-{{ _split_version[0] }}.{{ _split_version[1] }}.repo"
+        _scylla_repo_default: "https://downloads.scylladb.com/rpm/centos/scylla-{{ _split_version[0] }}.{{ _split_version[1] }}.repo"
 
     - name: Set scylla_rpm_repos
       set_fact:

--- a/ansible-scylla-node/tasks/upgrade/upgrade_debian.yml
+++ b/ansible-scylla-node/tasks/upgrade/upgrade_debian.yml
@@ -32,7 +32,7 @@
 # Create Scylla repositories file
 - name: Create Scylla repositories file
   ansible.builtin.get_url:
-    url: "http://downloads.scylladb.com/deb/debian/scylla-{{ scylla_upgrade['major_version'] }}.list"
+    url: "https://downloads.scylladb.com/deb/debian/scylla-{{ scylla_upgrade['major_version'] }}.list"
     dest: /etc/apt/sources.list.d/scylla.list
     mode: '0644'
   become: true

--- a/ansible-scylla-node/tasks/upgrade/upgrade_redhat.yml
+++ b/ansible-scylla-node/tasks/upgrade/upgrade_redhat.yml
@@ -13,7 +13,7 @@
 # Create Scylla repositories file
 - name: Create Scylla repositories file
   ansible.builtin.get_url:
-    url: "http://downloads.scylladb.com/rpm/centos/scylla-{{ scylla_upgrade['major_version'] }}.repo"
+    url: "https://downloads.scylladb.com/rpm/centos/scylla-{{ scylla_upgrade['major_version'] }}.repo"
     dest: /etc/yum.repos.d/scylla.repo
     mode: '0644'
   become: true

--- a/ansible-scylla-node/tasks/upgrade/upgrade_ubuntu.yml
+++ b/ansible-scylla-node/tasks/upgrade/upgrade_ubuntu.yml
@@ -32,7 +32,7 @@
 # Create Scylla repositories file
 - name: Create Scylla repositories file
   ansible.builtin.get_url:
-    url: "http://downloads.scylladb.com/deb/ubuntu/scylla-{{ scylla_upgrade['major_version'] }}.list"
+    url: "https://downloads.scylladb.com/deb/ubuntu/scylla-{{ scylla_upgrade['major_version'] }}.list"
     dest: /etc/apt/sources.list.d/scylla.list
     mode: '0644'
   become: true

--- a/example-playbooks/scylla_deploy/manager.yml
+++ b/example-playbooks/scylla_deploy/manager.yml
@@ -6,11 +6,11 @@
         host: "{{ groups['scylla'][0]}}"
         auth_token_file: scyllamgr_auth_token.txt
         without_repair: false
-    scylla_manager_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
+    scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
     #  These will be passed on to the ansible-scylla-node role applied to the Manager node in order to deploy a local Scylla instance
     scylla_manager_db_vars:
       scylla_repos:
-        - 'http://repositories.scylladb.com/scylla/repo/****/centos/scylladb-4.1.repo'
+        - 'https://repositories.scylladb.com/scylla/repo/****/centos/scylladb-4.1.repo'
       # Only for Ubuntu/Debian
       #scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
       #scylla_repo_keys:

--- a/example-playbooks/scylla_deploy/nodes.yml
+++ b/example-playbooks/scylla_deploy/nodes.yml
@@ -6,7 +6,7 @@
 
     # variables for the Scylla node role (can be set here or in the role's vars/main.yml)
     scylla_repos:
-      - 'http://repositories.scylladb.com/scylla/repo/****/centos/scylladb-4.1.repo'
+      - 'https://repositories.scylladb.com/scylla/repo/****/centos/scylladb-4.1.repo'
         #scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
         #scylla_repo_keys:
         #- 5e08fbd8b5d6ec9c
@@ -28,7 +28,7 @@
     scylla_api_port: '10000'
     generate_monitoring_config: True
     scylla_manager_enabled: true
-    scylla_manager_repo_url: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
+    scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
 
   roles:
     - ansible-scylla-node


### PR DESCRIPTION
Starting March 5 http access to downloads.scylladb.com is going to be blocked. Let's switch to using https.

Ref scylladb/scylla-pkg#3764