### PR TITLE
scylla-node: read io.conf before io_properties.yaml

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -85,6 +85,14 @@
 
 - name: Collect IO settings for the first node of every DC
   block:
+    - name: store /etc/scylla.d/io.conf
+      shell: |
+        cat /etc/scylla.d/io.conf
+      register: _io_conf
+
+    - set_fact:
+        io_conf: "{{ _io_conf.stdout_lines[0] }}"
+
     - name: check for existing io_properties
       stat:
         path: /etc/scylla.d/io_properties.yaml
@@ -102,14 +110,6 @@
 
     - set_fact:
         io_properties: "{{ _io_properties.stdout }}"
-
-    - name: store /etc/scylla.d/io.conf
-      shell: |
-        cat /etc/scylla.d/io.conf
-      register: _io_conf
-
-    - set_fact:
-        io_conf: "{{ _io_conf.stdout_lines[0] }}"
   when: io_properties is not defined and scylla_io_probe|bool == True and (scylla_io_probe_dc_aware|bool == False or dc_to_node_list[dc][0] == inventory_hostname)
   become: true
 


### PR DESCRIPTION
## Problem

Ran into this problem while trying to deploy a new cluster.

```
TASK [../../../roles/scylla-ansible-roles/ansible-scylla-node : Set io.conf] ******************************************************************************************************
fatal: [prod-scylla-nyj-1.example.com]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'io_conf'. 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'io_conf'\n\nThe error appears to be in '/Users/remi/code/infra/ansible/roles/scylla-ansible-roles/ansible-scylla-node/tasks/common.yml': line 143, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set io.conf\n  ^ here\n"}
```

As per the Ansible documentation for [blocks](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_blocks.html):

> The directive does not affect the block itself, it is only inherited by the tasks enclosed by a block. For example, a when statement is applied to the tasks within a block, not to the block itself.

Since the `io_conf` fact is set after the step to set the `io_properties` fact, the `when` clause for the block that checks whether `io_properties` is set will prevent the `io_conf` fact from ever being set. This in turns causes the `Set io.conf` task to fail as `io_conf` was never set.

## Solution

Doing the `io.conf` steps before the `io.properties` steps in the block solves the issue.