### PR TITLE
ansible-scylla-node: Add support for dc_suffix in generate_tokens task

### DIFF
--- a/ansible-scylla-node/tasks/generate_tokens.yml
+++ b/ansible-scylla-node/tasks/generate_tokens.yml
@@ -20,7 +20,7 @@
   set_fact:
     node_list: "{{ node_list | default([]) + [hostvars[item]['broadcast_address']] }}"
     rack_list: "{{ rack_list | default([]) + [hostvars[item]['rack']] }}"
-    dc_list: "{{ dc_list | default([]) + [hostvars[item]['dc']] }}"
+    dc_list: "{{ dc_list | default([]) + [hostvars[item]['dc'] + hostvars[item]['dc_suffix'] | default('')] }}"
   loop: "{{ groups['scylla'] }}"
 
 - name: Create a temporary tokens file


### PR DESCRIPTION
'dc_suffix' has to be appended to the 'DC' variable when defined.

Fixes #349