### PR TITLE
[Fix - scylla-node] - Ansible builtin + when condition start node

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -329,13 +329,14 @@
       run_once: true
       include_tasks: start_one_node.yml
       loop: "{{ groups['scylla'] }}"
-      when: hostvars[item]['broadcast_address'] in scylla_seeds or item in scylla_seeds
+      when: (hostvars[item]['broadcast_address'] is defined) and ((hostvars[item]['broadcast_address'] in scylla_seeds) or (item in scylla_seeds))
 
     - name: Start scylla non-seeds nodes serially
       run_once: true
       include_tasks: start_one_node.yml
       loop: "{{ groups['scylla'] }}"
       when:
+        - hostvars[item]['broadcast_address'] is defined
         - item not in scylla_seeds
         - hostvars[item]['broadcast_address'] not in scylla_seeds
 

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -305,17 +305,17 @@
 # have an actual value resolved.
 # One way to do that is to resolve it and store as an Ansible fact.
 - name: Resolve a scylla_listen_address as a fact
-  set_fact:
+  ansible.builtin.set_fact:
     listen_address: "{{ scylla_listen_address }}"
 
 # The same relates to the below
 - name: Resolve scylla_rpc_address
-  set_fact:
+  ansible.builtin.set_fact:
     rpc_address: "{{ scylla_rpc_address }}"
 
 # The same relates to the below
 - name: Resolve scylla_broadcast_address
-  set_fact:
+  ansible.builtin.set_fact:
     broadcast_address: "{{ scylla_broadcast_address }}"
 
 - name: start_scylla_service dependent tasks

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -304,7 +304,6 @@
 # Therefore in order to be able to get the corresponding value via hostvars[item] later in the play we need to
 # have an actual value resolved.
 # One way to do that is to resolve it and store as an Ansible fact.
-
 - name: Resolve a scylla_listen_address as a fact
   ansible.builtin.set_fact:
     listen_address: "{{ scylla_listen_address }}"


### PR DESCRIPTION
Hello Scylladb community,

First thanks for that amazing ansible role !!

I'm currently using your ansible-role to deploy a cluster from scratch and adding a node into a cluster. I'm using ansible `2.16` to match your requirement (`2.8`). Currently when I was using your examples I was facing some issues with 2 tasks : `Start scylla non-seeds nodes serially` | `Start seeders serially`. 

This issue append when I'm trying to add a node into the cluster.
My error was due to the `Resolve scylla_broadcast_address` task that was setting the fact only for the current node that run the task.
Then when we enter into `start_scylla_service dependent tasks` task, it will iterate over all the servers inside our current inventory and try to catch the `scylla_broadcast_address`. This variable is empty when we call the role for one node.

Examples : 

My inventory is like :
```
[scylla]
scylla-1
scylla-2
scylla-3
```
I want to add a new node `scylla-4` from the group `[new_node]`. 
My playbook is like : 
```
- name: Add Scylla node(s)
  hosts: "{{ ansible_limit }}"
  become: true
  gather_facts: true
  vars:
    full_inventory: false
  roles:
    - ansible-scylla-node
  tags: new_node

- name: Run cleanup on the old nodes
  hosts: "{{ target_host | default('scylla') }}"
  gather_facts: false
  serial: 1
  tasks:
    - name: Run cleanup
      script:  files/repair.sh
  tags: new_node
```
I call it like : `ansible-playbook scylla.yaml -i inventories/inventory.yml -u devops --diff -l scylla-4 -t new_node -e "@group_vars/scylla_poc"`
When I arrive at the task `scylla_broadcast_address` it will perform the set_fact only for my node `scylla-4`. Once I will run the task `Start seeders serially` ansible will iterate over `loop: "{{ groups['scylla'] }}"` but by design this should run only the new node.
That will iterate like : 

```
skipping: [scylla-4] => (scylla-1) --> Empty value for scylla_broadcast_address
skipping: [scylla-4] => (scylla-2) --> Empty value for scylla_broadcast_address
skipping: [scylla-4] => (scylla-3) --> Empty value for scylla_broadcast_address
skipping: [scylla-4] => (scylla-4) --> IP from the NIC not into seeder list
skipping: [scylla-4]
```

And same pattern append with `Start scylla non-seeds nodes serially` task.

My fix proposal is to add a new check to avoid crash errors on set_fact empty for `scylla_broadcast_address`.

Let me know if you need more to debug/discuss !

Thanks a lot in advance !
