### PR TITLE
scylla-node/Debian_install.yml: Don't check if the installed scylla v…

### DIFF
--- a/ansible-scylla-node/tasks/Debian_install.yml
+++ b/ansible-scylla-node/tasks/Debian_install.yml
@@ -19,7 +19,7 @@
     - name: "Validate scylla version correctness"
       ansible.builtin.fail:
         msg: "Too many/few choices for a requested version '{{ scylla_version_to_install }}': {{ aptversions.stdout_lines }}. Bailing out!"
-      when: aptversions.stdout_lines | length != 1
+      when: (not scylla_is_installed or upgrade_version) and aptversions.stdout_lines | length != 1
 
     - name: If Scylla is installed check if it's the same version as requested
       fail:


### PR DESCRIPTION
…ersion appears in the repo exactly once

We have a check that validates that a value in `scylla_version` matches exactly one (full) scylla verison from the repository so that the Role can install it.

However this check is only relevant when we are going to install anything, and when scylla is already installed - we are not going to. Hence, this check is only making noise in such a case.

One common example of such a situation is when a custom build is installed.