### PR TITLE
ansible-scylla-node: Fix io_properties example

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -232,7 +232,7 @@ always_replace_io_conf: False
 always_replace_io_properties: False
 
 # These can be arbitrarily set if scylla_io_probe is set to False
-# io_properties:
+# io_properties: |
 #   disks:
 #     - mountpoint: /var/lib/scylla/data
 #       read_iops: 10962999


### PR DESCRIPTION
The pipe needs to be added in order for the value to be read as a multi-line string.

Closes https://github.com/scylladb/scylla-ansible-roles/issues/374