### PR TITLE
replace_node.yml: Allow disabling RBNO for the new node during replace

### DIFF
--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -190,6 +190,26 @@
         create: yes
       when: _replace_node_first_boot_grep.failed
 
+    - name: Check if RBNO is available in the current Scylla version
+      shell: |
+        scylla --help | grep enable-repair-based-node-ops
+      register: _enable_rbno_grep
+      ignore_errors: true
+
+    - name: Check if RBNO was enabled for node replacement
+      block:
+        - command: cat /etc/scylla/scylla.yaml
+          ignore_errors: true
+          register: _scylla_yaml_out
+
+        - set_fact:
+            _scylla_yaml_map: "{{ _scylla_yaml_out.stdout | from_yaml }}"
+
+        - set_fact:
+            _rbno_enabled: "{{ _scylla_yaml_map.enable_repair_based_node_ops is not defined or _scylla_yaml_map.enable_repair_based_node_ops }}"
+            _rbno_allowed_for_replace: "{{ _scylla_yaml_map.allowed_repair_based_node_ops is not defined or 'replace' in _scylla_yaml_map.allowed_repair_based_node_ops }}"
+      when: _enable_rbno_grep.failed == false
+
     - name: Start Scylla
       service:
         name: scylla-server
@@ -222,26 +242,6 @@
         line: |
           \g<1> - seeds: {{ original_seeds }}
         backrefs: yes
-
-    - name: Check if RBNO is available in the current Scylla version
-      shell: |
-        scylla --help | grep enable-repair-based-node-ops
-      register: _enable_rbno_grep
-      ignore_errors: true
-
-    - name: Check if RBNO was enabled for node replacement
-      block:
-        - command: cat /etc/scylla/scylla.yaml
-          ignore_errors: true
-          register: _scylla_yaml_out
-
-        - set_fact:
-            _scylla_yaml_map: "{{ _scylla_yaml_out.stdout | from_yaml }}"
-
-        - set_fact:
-            _rbno_enabled: "{{ _scylla_yaml_map.enable_repair_based_node_ops is not defined or _scylla_yaml_map.enable_repair_based_node_ops }}"
-            _rbno_allowed_for_replace: "{{ _scylla_yaml_map.allowed_repair_based_node_ops is not defined or 'replace' in _scylla_yaml_map.allowed_repair_based_node_ops }}"
-      when: _enable_rbno_grep.failed == false
 
 
 - name: Wait for added node to become healthy and start scylla-manager-agent

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -210,6 +210,15 @@
             _rbno_allowed_for_replace: "{{ _scylla_yaml_map.allowed_repair_based_node_ops is not defined or 'replace' in _scylla_yaml_map.allowed_repair_based_node_ops }}"
       when: _enable_rbno_grep.failed == false
 
+    # RBNO will be re-enabled once the replace is finished
+    - name: Disable RBNO
+      lineinfile:
+        path: /etc/scylla/scylla.yaml
+        regexp: '^(#\s*)?enable_repair_based_node_ops:'
+        line: "enable_repair_based_node_ops: False"
+        create: yes
+      when: disable_rbno|bool and _rbno_enabled is defined and _rbno_enabled|bool
+
     - name: Start Scylla
       service:
         name: scylla-server
@@ -244,7 +253,7 @@
         backrefs: yes
 
 
-- name: Wait for added node to become healthy and start scylla-manager-agent
+- name: Wait for added node to become healthy and run post-replace tasks
   hosts: scylla
   vars_files:
     - vars/main.yml
@@ -263,6 +272,22 @@
         state: restarted
         enabled: yes
       become: true
+
+    - name: Re-enable RBNO for the new node
+      block:
+        - name: Set RBNO to true in scylla.yaml
+          lineinfile:
+            path: /etc/scylla/scylla.yaml
+            regexp: '^(#\s*)?enable_repair_based_node_ops:'
+            line: "enable_repair_based_node_ops: True"
+            create: yes
+
+        - name: Re-load scylla.yaml
+          shell: |
+            pkill -1 scylla$
+      delegate_to: "{{ new_node }}"
+      run_once: true
+      when: disable_rbno|bool and _rbno_enabled is defined and _rbno_enabled|bool
 
 
 - name: Resume scylla-manager tasks

--- a/example-playbooks/replace_node/vars/main.yml
+++ b/example-playbooks/replace_node/vars/main.yml
@@ -39,6 +39,10 @@ new_node_bootstrap_wait_time_sec: 25200
 # by draining/stopping the node being replaced before starting the replace
 alive_node_replace: false
 
+# If you set this to true, this playbook will disable RBNO for the new node
+# during the replace
+disable_rbno: false
+
 alive_nodes_listen_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 alive_nodes_broadcast_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 


### PR DESCRIPTION
When we're working in a cluster with mixed CPUSETs, it might be necessary to disable RBNO during a replace to avoid repair reader timeouts.
Having that in mind, this PR adds an option to disable RBNO only during the replace.