### PR TITLE
scylla-node: change net.ipv4.ip_local_port_range default tweaking

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -467,7 +467,7 @@ sysctl:
   - name: 'net.ipv4.tcp_synack_retries'
     value: '2'
   - name: 'net.ipv4.ip_local_port_range'
-    value: '2000 65535'
+    value: '20000 65535'
   - name: 'net.ipv4.tcp_rfc1337'
     value: '1'
   - name: 'net.ipv4.tcp_fin_timeout'


### PR DESCRIPTION
Allowing using ports from 2000 up is dangerous because scylla uses ports 9xxx and 19xxx for listening on.

This may end up with scylla conflicting with itself if it OS uses one of these ports for "client" side of the socket (e.g. RPC sockets) and eventually failing with the following error:

(CQLServer error while listening on 172.29.160.241:9042 -> std::system_error (error system:98, posix_listen failed for address 172.29.160.241:9042: Address already in use))

Let's increase the lower bound to 20000.