### PR TITLE
example_playbooks/run_cleanup: properly remove just hash of directory

### DIFF
--- a/example-playbooks/run_cleanup/files/cleanup.sh
+++ b/example-playbooks/run_cleanup/files/cleanup.sh
@@ -27,7 +27,8 @@ echo "cleaning first detected data dir:"; pwd
 PATHS=$(du -m --max-depth=2 .|sort -k1h|awk -F"/" 'NF==3'|awk '{ print $NF}'|grep -E -v '^./system/'\|'^./system_auth/'\|'^./system_distributed/'\|'^./system_traces/'\|'^./system_schema/')
 
 for i in $PATHS; do
-    TB=$(echo "$i"|awk -F'/' '{ print $NF }'|awk -F'-' '{ print $1 }')
+    FTB=$(echo "$i"|awk -F'/' '{ print $NF }')
+    TB=${FTB%-*}
     KS=$(echo "$i"|awk -F'/' '{ print $(NF - 1) }')
     echo "evaluating $DIR/$i/"
     if compgen -G "$DIR/$i/*.db" > /dev/null; then


### PR DESCRIPTION
instead of only getting first part until "-"

cql cannot have in table name "-" but
alternator can, so we cannot assume
that just first part until "-" is table name
logic has to be the other way, only whatever is after last "-" has to be deleted, all before is table name

fixes #387