### PR TITLE
ansible-scylla-node: Allow auto-detecting nvme cards

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -190,6 +190,7 @@ scylla_dependencies:
   - curl
   - wget
   - python3-yaml # this will fail on non centos systems
+  - nvme-cli
   #- software-properties-common
   #- apt-transport-https
   #- gnupg2
@@ -423,6 +424,10 @@ scylla_manager_agent_config: |
   # - /dev/nvme0n2
   # - /dev/nvme0n3
 scylla_raid_online_discard: False
+
+# If scylla_raid_setup is not given and this is set to True, the role will use 'nvme list' for getting the list of nvme devices
+# in the machine and pass all of them to scylla_raid_setup
+detect_nvmes: False
 
 skip_coredump: False
 devmode: False

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -120,6 +120,11 @@
     for i in `yum search python3|grep -i pyyaml|awk '{ print $1 }'`; do sudo yum -y install $i; done
   become: true
 
+- name: install nvme-cli
+  shell: |
+    yum install -y nvme-cli
+  become: true
+
 - name: install and configure Scylla Manager Agent
   block:
     - name: add Scylla Manager repo

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -48,6 +48,18 @@
       when: cpuset_command is defined and skip_cpuset is defined and skip_cpuset|bool == false
   become: true
 
+- name: Detect NVME disks
+  block:
+    - name: Get list of NVMEs
+      shell: |
+        nvme list | awk '{print $1}' | tail -n +3
+      register: _detected_nvmes
+
+    - set_fact:
+        scylla_raid_setup: "{{ _detected_nvmes.stdout_lines }}"
+  become: true
+  when: detect_nvmes|bool
+
 - name: configure RAID via Scylla-setup
   block:
     - name: check for current raid


### PR DESCRIPTION
This patch adds a `detect_nvmes` field, which when set to True will use 'nvme list' command for getting the list of nvme devices in the machine and pass all of them to scylla_raid_setup.