### PR TITLE
replace_node.yml: Add a block_replaced_node var

### DIFF
--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -95,6 +95,7 @@
         source: "{{ replaced_node_broadcast_address }}"
         jump: DROP
       become: true
+      when: block_replaced_node|bool
 
 
 # This play will install Scylla in the new node and update the existing ones.

--- a/example-playbooks/replace_node/vars/main.yml
+++ b/example-playbooks/replace_node/vars/main.yml
@@ -43,6 +43,10 @@ alive_node_replace: false
 # during the replace
 disable_rbno: false
 
+# If you set this to true, this playbook will block the replaced node's broadcast_address via iptables
+# in all nodes to prevent it from trying to join the cluster again
+block_replaced_node: true
+
 alive_nodes_listen_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 alive_nodes_broadcast_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 


### PR DESCRIPTION
From now on, let's block the replaced_node's broadcast address only if the 'block_replaced_node' var is set to True.
This way we'll be able to replace a node with itself when this variable is set to False.