### PR TITLE
replace_node.yml: Allow ignoring dead nodes during replace

### DIFF
--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -312,6 +312,7 @@
         state: restarted
         enabled: yes
       become: true
+      when: inventory_hostname == new_node
 
     - name: Re-enable RBNO for the new node
       block:
@@ -326,7 +327,7 @@
           shell: |
             pkill -1 scylla$
       become: true
-      when: disable_rbno|bool and _rbno_enabled is defined and _rbno_enabled|bool
+      when: inventory_hostname == new_node and disable_rbno|bool and _rbno_enabled is defined and _rbno_enabled|bool
 
 
 - name: Resume scylla-manager tasks

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -173,6 +173,32 @@
       delegate_to: "{{ temporary_seed }}"
       run_once: true
 
+    - name: Set ignore_dead_nodes_for_replace using host ids
+      block:
+        - name: Set dead nodes host ids
+          set_fact:
+            _dead_nodes_host_ids: "{{ _dead_nodes_host_ids | default([]) + [item.value] }}"
+          when: item.key in dead_nodes_to_ignore
+          loop: "{{ _host_ids.json }}"
+
+        - name: Set ignore_dead_nodes_for_replace in scylla.yaml
+          lineinfile:
+            path: /etc/scylla/scylla.yaml
+            regexp: '^(#\s*)?ignore_dead_nodes_for_replace:'
+            line: "ignore_dead_nodes_for_replace: {{ _dead_nodes_host_ids | join(',')}}"
+            create: yes
+      when: dead_nodes_to_ignore|length > 0 and _replace_node_first_boot_grep.failed == false
+
+    # If the _replace_node_first_boot_grep failed, it means that in this scylla version we are still using
+    # addresses instead of host ids for replace, so let's set broadcast addresses in ignore_dead_nodes_for_replace
+    - name: Set ignore_dead_nodes_for_replace using addresses
+      lineinfile:
+        path: /etc/scylla/scylla.yaml
+        regexp: '^(#\s*)?ignore_dead_nodes_for_replace:'
+        line: "ignore_dead_nodes_for_replace: {{ dead_nodes_to_ignore | join(',')}}"
+        create: yes
+      when: dead_nodes_to_ignore|length > 0 and _replace_node_first_boot_grep.failed
+
     - name: Set replace_node_first_boot
       block:
         - set_fact:
@@ -249,6 +275,13 @@
         regexp: '^replace_address_first_boot:'
         state: absent
       when: _replace_node_first_boot_grep.failed
+
+    - name: Remove the ignore_dead_nodes_for_replace record
+      lineinfile:
+        path: /etc/scylla/scylla.yaml
+        regexp: '^ignore_dead_nodes_for_replace:'
+        state: absent
+      when: dead_nodes_to_ignore|length > 0
 
     - name: Restore seeds list
       lineinfile:

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -162,18 +162,19 @@
       register: _replace_node_first_boot_grep
       ignore_errors: true
 
+    - name: Get the host id for all nodes
+      uri:
+        url: "http://{{ scylla_api_address }}:{{ scylla_api_port }}/storage_service/host_id"
+        method: GET
+      register: _host_ids
+      until: _host_ids.status == 200
+      retries: 5
+      delay: 1
+      delegate_to: "{{ temporary_seed }}"
+      run_once: true
+
     - name: Set replace_node_first_boot
       block:
-        - name: Get the host id for all nodes
-          uri:
-            url: "http://{{ scylla_api_address }}:{{ scylla_api_port }}/storage_service/host_id"
-            method: GET
-          register: _host_ids
-          until: _host_ids.status == 200
-          retries: 5
-          delay: 1
-          delegate_to: "{{ temporary_seed }}"
-
         - set_fact:
             _replaced_node_host_id: "{{ item.value }}"
           when: item.key == replaced_node or item.key == replaced_node_broadcast_address

--- a/example-playbooks/replace_node/vars/main.yml
+++ b/example-playbooks/replace_node/vars/main.yml
@@ -47,3 +47,7 @@ alive_nodes_listen_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 alive_nodes_broadcast_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 
 cql_port: 9042
+
+# A list with the broadcast addresses of the nodes that are dead and should be ignored during the replace
+# These nodes shouldn't be part of the inventory
+dead_nodes_to_ignore: []


### PR DESCRIPTION
Scylla has an `ignore_dead_nodes_for_replace` config which allows the user to ignore dead nodes during the replace and so far it was not supported by this playbook.
This PR adds support to this feature by adding a variable `dead_nodes_to_ignore`.