### PR TITLE
ansible-scylla-node: Add a way to set additional scylla command line …

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -245,6 +245,14 @@ always_replace_io_properties: False
 
 io_conf: 'SEASTAR_IO="--io-properties-file /etc/scylla.d/io_properties.yaml"'
 
+# This parameter allows overriding a default SCYLLA_ARGS value in /etc/default/scylla-server file
+# When defined and not empty SCYLLA_ARGS is going to be set the corresponding value.
+#
+# The provided value will be set in double quotes by the Role:
+# SCYLLA_ARGS="{{ scylla_args_value }}"
+#
+# scylla_args_value: "--log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix"
+
 # Seeds node list
 scylla_seeds:
   - "{{ groups['scylla'][0] }}"

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -162,6 +162,15 @@
   become: true
   when: _io_properties_file.stat.exists|bool == false or always_replace_io_properties|bool
 
+- name: Override SCYLLA_ARGS if requested
+  lineinfile:
+    path: /etc/default/scylla-server
+    regexp: '^SCYLLA_ARGS='
+    line: 'SCYLLA_ARGS="{{ scylla_args_value }}"'
+    create: yes
+  become: true
+  when: scylla_args_value is defined and scylla_args_value|length > 0
+
 - name: configure NTP
   shell: |
     scylla_ntp_setup


### PR DESCRIPTION
…parameters (e.g. seastar ones)

Before this patch we could have set additional scylla command line parameters in a hackish way via io_conf variable.
This patch adds an explicit way to set SCYLLA_ARGS macro in /etc/default/scylla-server file.

A new variable is added to achieve so: scylla_args_value. The non-empty value set to this variable is going to override/enforce the SCYLLA_ARGS.

Tested manually with value set and not set.