### PR TITLE
ansible-scylla-node: Fixes post-upgrade version check

### DIFF
--- a/ansible-scylla-node/tasks/upgrade/node_verification.yml
+++ b/ansible-scylla-node/tasks/upgrade/node_verification.yml
@@ -62,4 +62,4 @@
     version_installed: "{{ version_major_installed if upgrade_major else version_full_installed }}"
   ansible.builtin.fail:
     msg: "Version set ({{ version_specified }}) and version installed ({{ version_installed }}) are different, thus the upgrade failed."
-  when: version_installed not in version_specified
+  when: version_specified not in version_installed


### PR DESCRIPTION
This patch fixes the logic of how the version is checked during a minor upgrade, allowing to set a minor version as 'ABCD.E.F' instead of 'ABCD.E.F-G.H.I'

Fixes #401