### PR TITLE
Compatibility with newer Ansible versions (tested 2.17.5)

### DIFF
--- a/ansible-scylla-manager/meta/main.yml
+++ b/ansible-scylla-manager/meta/main.yml
@@ -24,6 +24,19 @@ galaxy_info:
     - scylla
     - scylla-manager
 
-dependencies: 
-  - ansible-scylla-node
-  
+dependencies:
+  - role: "ansible-scylla-node"
+    vars:
+      scylla_version: 'latest'
+      install_only: true
+      scylla_manager_enabled: false
+      scylla_edition: "{{ scylla_manager_db_vars.scylla_edition|default('oss') }}"
+      elrepo_kernel: false
+      scylla_repo_keyserver: "{{ scylla_manager_db_vars.scylla_repo_keyserver|default('') }}"
+      scylla_repo_keys: "{{ scylla_manager_db_vars.scylla_repo_keys|default([]) }}"
+      scylla_dependencies: "{{ scylla_manager_db_vars.scylla_dependencies|default([]) }}"
+      scylla_ssl:
+        internode:
+          enabled: false
+        client:
+          enabled: false

--- a/ansible-scylla-manager/tasks/main.yml
+++ b/ansible-scylla-manager/tasks/main.yml
@@ -1,24 +1,4 @@
 ---
-- name: deploy local Scylla on the Manager node
-  import_role:
-    name: "{{ role_path }}/../ansible-scylla-node"
-  vars:
-  # TODO how to use scylla_manager_db_vars to be passed on as role params?
-    install_only: True
-    scylla_manager_enabled: false
-    scylla_version: 'latest'
-    scylla_edition: "{{ scylla_manager_db_vars.scylla_edition|default('oss') }}"
-    elrepo_kernel: false
-    scylla_repo_keyserver: "{{ scylla_manager_db_vars.scylla_repo_keyserver|default('') }}"
-    scylla_repo_keys: "{{ scylla_manager_db_vars.scylla_repo_keys|default([]) }}"
-    scylla_dependencies: "{{ scylla_manager_db_vars.scylla_dependencies|default([]) }}"
-    scylla_ssl:
-      internode:
-        enabled: false
-      client:
-        enabled: false
-
-
 - name: install Scylla Manager
   include_tasks: "{{ ansible_os_family }}.yml"
 

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -11,7 +11,7 @@
         - firewalld.service
         - iptables_services.service
         - ufw.service
-      when: ansible_facts.services[item] is defined
+      when: ansible_facts.services[item] is defined and ansible_facts.services[item]['status'] != 'not-found'
     - name: Flush all iptables rules
       iptables:
         flush: yes

--- a/ansible-scylla-node/tasks/generate_tokens.yml
+++ b/ansible-scylla-node/tasks/generate_tokens.yml
@@ -8,7 +8,6 @@
   ignore_errors: true
   delegate_to: "{{ item }}"
   loop: "{{ groups['scylla'] }}"
-  when: wait_for_cql_port_output is not defined or wait_for_cql_port_output.failed == True
 
 - name: Set the already bootstrapped node as a fact, if any
   set_fact:

--- a/ansible-scylla-node/tasks/manager_agents.yml
+++ b/ansible-scylla-node/tasks/manager_agents.yml
@@ -61,7 +61,3 @@
     enabled: yes
   become: true
   when: manager_agent_config_change.changed and start_scylla_service is defined and start_scylla_service|bool
-  ignore_errors: true
-  #TODO: remove ignore_errors when ansible is bumped to 2.10.4 or 2.9.16 as per https://github.com/ansible/ansible/issues/71528
-
-

--- a/example-playbooks/async_extra/action_plugins/async_alias.py
+++ b/example-playbooks/async_extra/action_plugins/async_alias.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 ScyllaDB

--- a/example-playbooks/async_extra/action_plugins/async_kill.py
+++ b/example-playbooks/async_extra/action_plugins/async_kill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 ScyllaDB

--- a/example-playbooks/async_extra/action_plugins/async_status_id.py
+++ b/example-playbooks/async_extra/action_plugins/async_status_id.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 ScyllaDB

--- a/example-playbooks/async_extra/action_plugins/async_task.py
+++ b/example-playbooks/async_extra/action_plugins/async_task.py
@@ -374,9 +374,9 @@ class ActionModule(ActionBase):
     def v2_on_result(self, host, task, result):
         handler = self._shared_loader_obj.callback_loader.get('default')
         handler._display = self._display
-        handler.display_ok_hosts = True
-        handler.display_failed_stderr = True
-        handler.display_skipped_hosts = True
+        handler.set_option('display_ok_hosts', True)
+        handler.set_option('display_failed_stderr', True)
+        handler.set_option('display_skipped_hosts', True)
 
         payload = TaskResult(host=host, task=task, return_data=result, task_fields=self._task.dump_attrs())
 

--- a/example-playbooks/async_extra/action_plugins/async_task.py
+++ b/example-playbooks/async_extra/action_plugins/async_task.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 ScyllaDB

--- a/example-playbooks/async_extra/action_plugins/async_wait.py
+++ b/example-playbooks/async_extra/action_plugins/async_wait.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 ScyllaDB

--- a/example-playbooks/async_extra/library/async_kill.py
+++ b/example-playbooks/async_extra/library/async_kill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 ScyllaDB

--- a/example-playbooks/async_extra/library/async_status_id.py
+++ b/example-playbooks/async_extra/library/async_status_id.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 ScyllaDB


### PR DESCRIPTION
This patch introduces several fixes to allow compatibility with newer ansible versions.
Ansible versions 2.14 or older are EOL ([source](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix))

The patch introduces the following:
- Patches the async plugin library
- Patches scylla-ansible-manager to properly pass variables to the scylla-ansible-node role with newer Ansible versions.
- Patches a bug in deactivation of services: Services were listed as a fact but with a 'non-found' status.
- Detects errors when scylla-manager does not start.

Fixes #409: A newer Ansible version was required to execute properly with Ubuntu 24 which came with a newer Python version out-of-the-box, which was not supported by older Ansible versions.