### PR TITLE
ansible-scylla-node: prevent minor upgrade from failing when the destination scylla version is already installed

### DIFF
--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -301,6 +301,6 @@
       ansible.builtin.wait_for:
         timeout: "{{ upgrade_break_before_verification |int }}"
 
-    - name: Verify if the upgrade was done sucessfully
+    - name: Verify if the upgrade was done successfully
       include_tasks: node_verification.yml
   

--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -144,7 +144,7 @@
 # Scylla version validation
 - name: Check if Scylla version was specified incorrectly
   vars:
-    version_format: "{{ 'X.Y.Z' if scylla_upgrade['edition'] else 'UVWX.Y.Z' }}"
+    version_format: "{{ 'X.Y.Z' if scylla_upgrade['edition'] == 'oss' else 'UVWX.Y.Z' }}"
   ansible.builtin.fail:
     msg: "Version {{ scylla_upgrade['version'] }} specified for Scylla {{ scylla_upgrade['edition_friendly_name'] }} is incomplete and can't be used for a minor upgrade. Version format is: '{{ version_format }}'."
   when:

--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -283,10 +283,6 @@
 # Upgrade verification
 - name: Upgrade verification
   block:
-    - name: "Wait {{ upgrade_break_before_verification }} seconds before verifying the upgrade"
-      ansible.builtin.wait_for:
-        timeout: "{{ upgrade_break_before_verification |int }}"
-
     - name: Verify if the upgrade was done sucessfully
       include_tasks: node_verification.yml
   rescue:

--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -125,11 +125,10 @@
 
 
 # Scylla upgrade information
-# ----- TODO: CHANGE THIS TASK TO ALLOW 'latest' FOR MINOR UPGRADES -----
 - name: Gather information about Scylla upgrade
   vars:
     is_oss_selected: "{{ true if scylla_edition == 'oss' else false }}"
-    final_version: "{{ scylla_version if scylla_version != 'latest' else scylla_support[ansible_facts['distribution'] |lower][ansible_facts['distribution_major_version']][scylla_edition] |first }}"
+    final_version: "{{ scylla_version_to_install }}"
   ansible.builtin.set_fact:
     # If this fact should be updated later, it should be updated entirely due to its structure
     scylla_upgrade: {
@@ -149,7 +148,6 @@
   ansible.builtin.fail:
     msg: "Version {{ scylla_upgrade['version'] }} specified for Scylla {{ scylla_upgrade['edition_friendly_name'] }} is incomplete and can't be used for a minor upgrade. Version format is: '{{ version_format }}'."
   when:
-    - scylla_version != 'latest'
     - scylla_upgrade['version'] == scylla_upgrade['major_version']
     - not upgrade_major
 
@@ -306,6 +304,3 @@
     - name: Verify if the upgrade was done sucessfully
       include_tasks: node_verification.yml
   
-
-  # ----- TODO: If the upgrade version is the latest one and if 'latest' was used to specify the version
-  # replace upgrade version with latest

--- a/ansible-scylla-node/tasks/upgrade/main.yml
+++ b/ansible-scylla-node/tasks/upgrade/main.yml
@@ -93,13 +93,15 @@
     is_scylla_installed: "{{ is_oss_installed or is_enterprise_installed }}"
     edition_installed: "{{ 'oss' if is_oss_installed else 'enterprise' }}"
     package_installed: "{{ 'scylla' if is_oss_installed else 'scylla-enterprise' }}"
+    full_version: "{{ ansible_facts.packages[package_installed][0].version }}"
+    full_version_split: "{{ (full_version.split('-')[0]).split('.') }}"
   ansible.builtin.set_fact:
     scylla_detected: {
       edition: "{{ edition_installed }}",
       edition_friendly_name: "{{ 'Open Source' if is_oss_installed else 'Enterprise' }}",
       package_name: "{{ package_installed }}",
-      version: "{{ ansible_facts.packages[package_installed][0].version }}",
-      major_version: "{{ (ansible_facts.packages[package_installed][0].version).split('.')[0] }}.{{ (ansible_facts.packages[package_installed][0].version).split('.')[1] }}"
+      version: "{{ full_version_split[0] }}.{{ full_version_split[1] }}.{{ full_version_split[2] }}",
+      major_version: "{{ full_version_split[0] }}.{{ full_version_split[1] }}"
     }
   when: is_scylla_installed
 
@@ -129,13 +131,15 @@
   vars:
     is_oss_selected: "{{ true if scylla_edition == 'oss' else false }}"
     final_version: "{{ scylla_version_to_install }}"
+    final_version_split: "{{ (final_version.split('-')[0]).split('.') }}"
   ansible.builtin.set_fact:
     # If this fact should be updated later, it should be updated entirely due to its structure
     scylla_upgrade: {
       edition: "{{ scylla_edition }}",
       edition_friendly_name: "{{ 'Open Source' if is_oss_selected else 'Enterprise' }}",
-      version: "{{ final_version }}",
-      major_version: "{{ final_version.split('.')[0] }}.{{ final_version.split('.')[1] }}",
+      full_version: "{{ final_version }}",
+      version: "{{ final_version_split[0] }}.{{ final_version_split[1] }}.{{ final_version_split[2] }}",
+      major_version: "{{ final_version_split[0] }}.{{ final_version_split[1] }}",
       id: "{{ ansible_date_time.epoch }}",
       upgrade: true
     }

--- a/ansible-scylla-node/tasks/upgrade/post_upgrade.yml
+++ b/ansible-scylla-node/tasks/upgrade/post_upgrade.yml
@@ -8,3 +8,8 @@
   notify: scylla-manager-agent restart
   become: true
 
+- name: Wait for CQL port
+  wait_for:
+    port: 9042
+    host: "{{ scylla_listen_address }}"
+


### PR DESCRIPTION
Versions sanity checks only make sense when one upgrades to official builds.
For custom builds upgrades one is going to disable these sanity checks anyway using upgrade_allow_user_manual_downgrade.

Therefore we can use MAJOR.MINOR.PATCH parts of installed and to-be-installed Scylla versions for sanity checking.
