### PR TITLE
fix(repo_keys): add a43e06657bac99e3 key

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -169,6 +169,7 @@ scylla_repo_keys:
   - 491c93b9de7496a7
   - d0a112e067426ab2
   - 5e08fbd8b5d6ec9c
+  - a43e06657bac99e3
 
 scylla_repo_keyring_dir: /etc/apt/keyrings/
 scylla_repo_keyringfile: "{{ scylla_repo_keyring_dir }}/scylladb.gpg"
@@ -179,6 +180,7 @@ scylla_manager_repo_keys:
   - 5e08fbd8b5d6ec9c
   - 6B2BFD3660EF3F5B
   - 17723034C56D4B19
+  - a43e06657bac99e3
 
 
 # Set when relevant (Debian for example)


### PR DESCRIPTION
Have issue with fresh install, solves with new key added to keyring

```
TASK [ansible_scylla_node : Run "apt-get update"] *********************************************************************************************************************
fatal: [XXX]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., W:GPG error: https://downloads.scylladb.com/downloads/scylla/deb/debian-ubuntu/scylladb-6.2 stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A43E06657BAC99E3, E:The repository 'https://downloads.scylladb.com/downloads/scylla/deb/debian-ubuntu/scylladb-6.2 stable InRelease' is not signed."}
```

[Key info](https://keyserver.ubuntu.com/pks/lookup?search=A43E06657BAC99E3&fingerprint=on&op=index)