### PR TITLE
replace_node.yml: Remove unnecessary seeds validation

### DIFF
--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -15,12 +15,6 @@
       set_fact:
         broadcast_address: "{{ alive_nodes_broadcast_address }}"
 
-    - name: "Check if the replaced node is in the seeds list"
-      fail:
-        msg: "The replaced node can't be a seed!"
-      when: replaced_node_broadcast_address in scylla_seeds or replaced_node in scylla_seeds
-      run_once: true
-
     - name: Stop scylla-server on the node being replaced
       block:
         - name: Disable Scylla service


### PR DESCRIPTION
This validation could prevent a user from replacing a node with itself when this node happens to be a seed, and it's completely unnecessary, since later on we have a task for temporarily changing the seed to an already bootstrapped node before starting the replace.