### PR TITLE
scylla-node/templates: properly handle structured values

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -414,18 +414,18 @@ scylla_manager_agent_upgrade: true
 
 # Manager Agent Backup configuration - this is a YAML value that will be inserted into the configuration file.
 # Please refer to the example configuration file and the documentation for detailed instructions.
-scylla_manager_agent_config:
-  s3:
-    access_key_id: 12345678
-    secret_access_key: QWerty123456789
-    provider: AWS
-    region: us-east-1c
-    endpoint: https://foo.bar.baz
-    server_side_encryption:
-    sse_kms_key_id:
-    upload_concurrency: 2
-    chunk_size: 50M
-    use_accelerate_endpoint: false
+#scylla_manager_agent_config:
+#  s3:
+#    access_key_id: 12345678
+#    secret_access_key: QWerty123456789
+#    provider: AWS
+#    region: us-east-1c
+#    endpoint: https://foo.bar.baz
+#    server_side_encryption:
+#    sse_kms_key_id:
+#    upload_concurrency: 2
+#    chunk_size: 50M
+#    use_accelerate_endpoint: false
 
 # Configure raid disks via scylla_setup. This requires a list of disks to add to the raid
 # scylla_raid_setup:

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -237,7 +237,7 @@ always_replace_io_conf: False
 always_replace_io_properties: False
 
 # These can be arbitrarily set if scylla_io_probe is set to False
-# io_properties: |
+# io_properties:
 #   disks:
 #     - mountpoint: /var/lib/scylla/data
 #       read_iops: 10962999
@@ -412,10 +412,9 @@ scylla_manager_rpm_repo_url: "{{ scylla_manager_repo_url }}"
 
 scylla_manager_agent_upgrade: true
 
-# Manager Agent Backup configuration - this is a free text which will be inserted into the configuration file
-# Please ensure it is a valid and working configuration. Please refer to the example configuration file and the
-# documentation for detailed instructions
-scylla_manager_agent_config: |
+# Manager Agent Backup configuration - this is a YAML value that will be inserted into the configuration file.
+# Please refer to the example configuration file and the documentation for detailed instructions.
+scylla_manager_agent_config:
   s3:
     access_key_id: 12345678
     secret_access_key: QWerty123456789

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -120,7 +120,7 @@
       register: _io_properties
 
     - set_fact:
-        io_properties: "{{ _io_properties.stdout }}"
+        io_properties: "{{ _io_properties.stdout | from_yaml }}"
 
     - name: store /etc/scylla.d/io.conf
       shell: |

--- a/ansible-scylla-node/templates/io_properties.yaml.j2
+++ b/ansible-scylla-node/templates/io_properties.yaml.j2
@@ -1,5 +1,5 @@
 {% if scylla_io_probe|bool and scylla_io_probe_dc_aware|bool %}
-{{ hostvars[dc_to_node_list[dc][0]]['io_properties'] }}
+{{ hostvars[dc_to_node_list[dc][0]]['io_properties'] | to_yaml(indent=2) }}
 {% else %}
-{{ io_properties }}
+{{ io_properties | to_yaml(indent=2) }}
 {% endif %}

--- a/ansible-scylla-node/templates/scylla-manager-agent.yaml.j2
+++ b/ansible-scylla-node/templates/scylla-manager-agent.yaml.j2
@@ -1,5 +1,5 @@
 auth_token: {{ auth_token }}
 
-{% if scylla_manager_agent_config is defined %}
-{{ scylla_manager_agent_config }}
+{% if scylla_manager_agent_config is defined and scylla_manager_agent_config is not none %}
+{{ scylla_manager_agent_config | to_yaml(indent=2) }}
 {% endif %}


### PR DESCRIPTION
This PR ensures that the JINJA templates output structured YAML values for scylla_manager_agent_config and io_properties instead of defaulting to JSON.

* Updates the io_properties comment to remove the pipe indicating a literal block style.
* Revises the scylla_manager_agent_config comment to clarify that the value is now expected as YAML.
