### PR TITLE
ansible-scylla-node: remove default scylla_seeds

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -295,9 +295,14 @@ io_conf: 'SEASTAR_IO="--io-properties-file /etc/scylla.d/io_properties.yaml"'
 #
 # scylla_args_value: "--log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix"
 
-# Seeds node list
-scylla_seeds:
-  - "{{ groups['scylla'][0] }}"
+# Seeds node list (mandatory parameter)
+# A seed should be either a DNS resolvable address (e.g. hostname) that is resolvable by all nodes in the cluster, 
+# or an IP address that is accessible by all nodes in the cluster.
+# If the hostname is not resolvable by all nodes, then such an IP address can be set, for example, explicitly or via ansible_host.
+# Do not use the below default example if ansible_host is not specified and the hostname is not resolvable by all nodes.
+#
+#scylla_seeds:
+#  - "{{ hostvars[groups.scylla.0].ansible_host if 'ansible_host' in hostvars[groups.scylla.0] else groups.scylla.0 }}"
 
 scylla_listen_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 scylla_rpc_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -296,13 +296,13 @@ io_conf: 'SEASTAR_IO="--io-properties-file /etc/scylla.d/io_properties.yaml"'
 # scylla_args_value: "--log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix"
 
 # Seeds node list (mandatory parameter)
-# A seed should be either a DNS resolvable address (e.g. hostname) that is resolvable by all nodes in the cluster, 
+# A seed should be either a DNS resolvable address (e.g. hostname) that is resolvable by all nodes in the cluster,
 # or an IP address that is accessible by all nodes in the cluster.
 # If the hostname is not resolvable by all nodes, then such an IP address can be set, for example, explicitly or via ansible_host.
 # Do not use the below default example if ansible_host is not specified and the hostname is not resolvable by all nodes.
 #
 #scylla_seeds:
-#  - "{{ hostvars[groups.scylla.0].ansible_host if 'ansible_host' in hostvars[groups.scylla.0] else groups.scylla.0 }}"
+#  - "{{ hostvars[groups['scylla'][0]].ansible_host if 'ansible_host' in hostvars[groups['scylla'][0]] else groups['scylla'][0] }}"
 
 scylla_listen_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"
 scylla_rpc_address: "{{ vars['ansible_'~scylla_nic].ipv4.address }}"

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -1,4 +1,15 @@
 ---
+
+# Sanity check: scylla_seeds has no default and is mandatory since there is no
+# hostname/IP that can be safely assumed reachable by all nodes in the cluster.
+- name: "Sanity check: scylla_seeds must be explicitly defined"
+  fail:
+    msg: >-
+      scylla_seeds is not defined or empty. Set it explicitly, e.g. to a DNS resolvable
+      hostname reachable by all nodes, or an IP address (possibly via ansible_host).
+      See defaults/main.yml for an example.
+  when: scylla_seeds is not defined or scylla_seeds | length == 0
+
 - name: General, NIC and CPU settings related tweaking
   block:
     - name: configure Scylla


### PR DESCRIPTION
The assumption cannot be made that the hostname is DNS resolvable by all nodes in the cluster. It's more appropriate to require that the seed nodes are specified explicitly.