### PR TITLE
ansible-scylla-monitoring: default grafana_admin_password

### DIFF
--- a/ansible-scylla-monitoring/defaults/main.yml
+++ b/ansible-scylla-monitoring/defaults/main.yml
@@ -98,5 +98,5 @@ prometheus_url: 'https://github.com/prometheus/prometheus/releases/download/v2.3
 # User configuration
 ####################################
 grafana_admin_user: "admin"
-# grafana_admin_password: "admin"
+grafana_admin_password: "admin"
 # grafana_viewer_password (in case a viewer user, with username: 'viewer', should be created)


### PR DESCRIPTION
The default password was implicitly 'admin', but it is more prudent to be explicit about this case.