### PR TITLE
Manager improvements: Improved defaults and allow override of Manager its local ScyllaDB version

### DIFF
--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -2,11 +2,8 @@
 # defaults file for ansible-scylla-manager
 
 # Repo URL for the Manager
-# deprecated in favour of below, it will be dropped soon, below should be used
-scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
-
 scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
-scylla_manager_rpm_repo_url: "{{ scylla_manager_repo_url }}"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
 
 scylla_manager_db_vars:
   # Repo URLs for the ScyllaDB datastore installation

--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -5,18 +5,17 @@
 scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.5.list"
 scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.5.repo"
 
-scylla_manager_db_vars:
-  # Repo URLs for the ScyllaDB datastore installation
-  # More information on the variables can be found in the documentation for the scylla-node role and it's heavily
-  # commented `defaults/main.yml` file
-  # scylla_repos:
-  #   - 'https://repositories.scylladb.com/scylla/repo/centos/scylladb-4.6.repo'
+# The manager installs a local ScyllaDB, which is used only by the Manager.
+# Repo URLs for the ScyllaDB datastore installation
+# More information on the variables can be found in the documentation for the scylla-node role and it's heavily
+# commented `defaults/main.yml` file
+# scylla_repos:
+#   - 'https://repositories.scylladb.com/scylla/repo/centos/scylladb-4.6.repo'
 
-  # # Set when relevant (Debian/Ubuntu)
-  # scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
-  # scylla_repo_keys:
-  #   - 5e08fbd8b5d6ec9c
-
+# # Set when relevant (Debian/Ubuntu)
+# scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
+# scylla_repo_keys:
+#   - 5e08fbd8b5d6ec9c
 scylla_repo_keyring_dir: /etc/apt/keyrings/
 scylla_repo_keyringfile: "{{ scylla_repo_keyring_dir }}/scylladb.gpg"
 

--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -2,8 +2,8 @@
 # defaults file for ansible-scylla-manager
 
 # Repo URL for the Manager
-scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
-scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.5.list"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.5.repo"
 
 scylla_manager_db_vars:
   # Repo URLs for the ScyllaDB datastore installation

--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -16,6 +16,7 @@ scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb
 # scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
 # scylla_repo_keys:
 #   - 5e08fbd8b5d6ec9c
+scylla_version: 'latest'
 scylla_repo_keyring_dir: /etc/apt/keyrings/
 scylla_repo_keyringfile: "{{ scylla_repo_keyring_dir }}/scylladb.gpg"
 

--- a/ansible-scylla-manager/meta/main.yml
+++ b/ansible-scylla-manager/meta/main.yml
@@ -27,7 +27,6 @@ galaxy_info:
 dependencies:
   - role: "ansible-scylla-node"
     vars:
-      scylla_version: 'latest'
       install_only: true
       scylla_manager_enabled: false
       elrepo_kernel: false

--- a/ansible-scylla-manager/meta/main.yml
+++ b/ansible-scylla-manager/meta/main.yml
@@ -30,11 +30,7 @@ dependencies:
       scylla_version: 'latest'
       install_only: true
       scylla_manager_enabled: false
-      scylla_edition: "{{ scylla_manager_db_vars.scylla_edition|default('oss') }}"
       elrepo_kernel: false
-      scylla_repo_keyserver: "{{ scylla_manager_db_vars.scylla_repo_keyserver|default('') }}"
-      scylla_repo_keys: "{{ scylla_manager_db_vars.scylla_repo_keys|default([]) }}"
-      scylla_dependencies: "{{ scylla_manager_db_vars.scylla_dependencies|default([]) }}"
       scylla_ssl:
         internode:
           enabled: false

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -405,8 +405,8 @@ system_info_encryption_kms:
 # If Scylla Manager will be used, set the following variables
 scylla_manager_enabled: true
 
-scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
-scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.5.list"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.5.repo"
 
 scylla_manager_agent_upgrade: true
 

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -404,11 +404,9 @@ system_info_encryption_kms:
 
 # If Scylla Manager will be used, set the following variables
 scylla_manager_enabled: true
-# deprecated in favour of below, it will be dropped soon, below should be used
-scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
 
 scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6.list"
-scylla_manager_rpm_repo_url: "{{ scylla_manager_repo_url }}"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
 
 scylla_manager_agent_upgrade: true
 

--- a/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
@@ -57,7 +57,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_edition: "enterprise"
-        scylla_version: "latest"
+        scylla_version: "2024.1.15"
         scylla_io_probe: false
         io_properties:
           disks:

--- a/example-playbooks/scylla_deploy/manager.yml
+++ b/example-playbooks/scylla_deploy/manager.yml
@@ -6,20 +6,6 @@
         host: "{{ groups['scylla'][0]}}"
         auth_token_file: scyllamgr_auth_token.txt
         without_repair: false
-    scylla_manager_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
-    #  These will be passed on to the ansible-scylla-node role applied to the Manager node in order to deploy a local Scylla instance
-    scylla_manager_db_vars:
-      scylla_repos:
-        - 'https://repositories.scylladb.com/scylla/repo/****/centos/scylladb-4.1.repo'
-      # Only for Ubuntu/Debian
-      #scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
-      #scylla_repo_keys:
-      #  - 5e08fbd8b5d6ec9c
-      #  - 6B2BFD3660EF3F5B
-      #  - 17723034C56D4B19
-      scylla_dependencies:
-        - curl
-        - wget
 
   roles:
     - role: ansible-scylla-manager


### PR DESCRIPTION
This PR introduces a number of improvements:

- The deprecated parameter `scylla_manager_repo_url` has been removed.
- The manager repo URLs have been updated to a more recent version.
- Manager role now can re-use certain defaults present in the scylla-node role which were being overridden
- The Manager its local ScyllaDB version can now be specified instead of always being the latest version.
- Certain outdated defaults in the Manager playbook have been removed.