### PR TITLE
Use the correct Scylla Cluster identity with Scylla Manager code parts

### DIFF
--- a/example-playbooks/replace_node/README.md
+++ b/example-playbooks/replace_node/README.md
@@ -29,7 +29,7 @@ New inventory:
   10.0.0.3
 ```
 
-2. Run `ansible-playbook -i inventory.ini -e "@nodes_params.yml" -e "@monitor_params.yml" -e "replaced_node=10.0.0.2" -e "replaced_node_broadcast_address=10.0.0.2" -e "new_node=10.0.0.4" replace_node.yml`
+2. Run `ansible-playbook -i inventory.ini -e "@manager_params.yml" -e "@nodes_params.yml" -e "@monitor_params.yml" -e "replaced_node=10.0.0.2" -e "replaced_node_broadcast_address=10.0.0.2" -e "new_node=10.0.0.4" replace_node.yml`
 
 ## Steps:
 
@@ -46,9 +46,11 @@ New inventory:
 
 ## Parameters:
 
-This playbook uses the node role to install and configure Scylla in the new node, so the same parameters
+This playbook uses the node role to install and configure Scylla in the new node, set it up in the Scylla Monitoring
+and use Scylla Manager to issue a repair if needed.
+So the same parameters for all three roles (node, monitoring and manager) that were
 used when the cluster was created should also be passed to the `replace_node.yml` playbook.
-In the `Usage` section of this README, we use `nodes_params.yml` and `monitor_params.yml` files to represent such parameters.
+See the `Usage` section of this README for the way how these parameters are supposed to be passed.
 
 Besides the vars from the node role, this playbook has the following mandatory parameters: `replaced_node`, `replaced_node_broadcast_address` and `new_node`.
 These and the other available parameters are listed and described in `vars/main.yml`.

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -276,7 +276,7 @@
       wait_for:
         port: "{{ cql_port }}"
         host: "{{ listen_address }}"
-        timeout: "{{ new_node_bootstrap_wait_time_sec }}"
+        timeout: "{{ new_node_bootstrap_wait_time_sec|int }}"
 
     - name: Remove the replace_node_first_boot record
       lineinfile:

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -140,7 +140,8 @@
     - vars/main.yml
   tasks:
     - name: Suspend tasks
-      shell: sctool --cluster="{{ scylla_cluster_name }}" suspend
+      shell: sctool --cluster="{{ item.cluster_name }}" suspend
+      loop: "{{ scylla_clusters }}"
 
 
 # This play will set the ip/host_id of the replaced node in the scylla.yaml of the new node,
@@ -352,7 +353,8 @@
     - vars/main.yml
   tasks:
     - name: Suspend tasks
-      shell: sctool --cluster="{{ scylla_cluster_name }}" resume
+      shell: sctool --cluster="{{ item.cluster_name }}" resume
+      loop: "{{ scylla_clusters }}"
 
 
 # This play will repair the new node if RBNO was not used and skip_repair is not set to true
@@ -368,21 +370,33 @@
 
     - name: Get cluster id
       shell: |
-        sctool status | grep 'Cluster: {{ scylla_cluster_name }} ' | awk '{print $3}' | tr -d '()'
+        if sctool status -c "{{ item.cluster_name }}" | grep -w "{{ hostvars[new_node]['broadcast_address'] }}" > /dev/null; then echo "{{ item.cluster_name }}"; else echo ""; fi
+      loop: "{{ scylla_clusters }}"
       register: _cluster_id
 
-    - fail:
-        msg: "Unable to find cluster {{ scylla_cluster_name }} in scylla-manager"
-      when: _cluster_id.stdout|length == 0
+    - name: Count non-empty stdout values in _cluster_id
+      set_fact:
+        cluster_with_new_node: "{{ _cluster_id.results | json_query('[?stdout != ``]') | json_query('[].stdout') }}"
 
+    - name: Check if the new node is managed by any Scylla Manager cluster
+      fail:
+        msg: "Unable to find Scylla Manager cluster managing {{ hostvars[new_node]['broadcast_address'] }} in scylla-manager"
+      when: cluster_with_new_node|length == 0
+
+    - name: Check if the new node is managed by exactly one Scylla Manager cluster
+      fail:
+        msg: "More than a single Scylla Manager cluster managing {{ hostvars[new_node]['broadcast_address'] }} in scylla-manager"
+      when: cluster_with_new_node|length > 1
+
+    # If we've got here, there is exactly one value in a {{ cluster_with_new_node }} list
     - name: Repair the new node
       shell: |
-        sctool repair --cluster "{{ _cluster_id.stdout }}" --host "{{ hostvars[new_node]['broadcast_address'] }}" {{ extra_repair_params }}
+        sctool repair --cluster "{{ cluster_with_new_node[0] }}" --host "{{ hostvars[new_node]['broadcast_address'] }}" {{ extra_repair_params }}
       register: _repair_id
 
     - name: Wait for the repair to finish
       shell:
-        sctool progress "{{ _repair_id.stdout }}" --cluster "{{ _cluster_id.stdout }}" | grep "Status:" | awk '{print $2}'
+        sctool progress "{{ _repair_id.stdout }}" --cluster "{{ cluster_with_new_node[0] }}" | grep "Status:" | awk '{print $2}'
       register: _repair_status
       until: _repair_status.stdout != "RUNNING"
       retries: "{{ new_node_repair_timeout_seconds|int // 30 }}" # retries = new_node_repair_timeout_seconds / delay

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -139,7 +139,7 @@
   vars_files:
     - vars/main.yml
   tasks:
-    - name: Suspend tasks
+    - name: Suspend SM tasks on all configured clusters
       shell: sctool --cluster="{{ item.cluster_name }}" suspend
       loop: "{{ scylla_clusters }}"
 
@@ -352,7 +352,7 @@
   vars_files:
     - vars/main.yml
   tasks:
-    - name: Suspend tasks
+    - name: Resume SM tasks on all configured clusters
       shell: sctool --cluster="{{ item.cluster_name }}" resume
       loop: "{{ scylla_clusters }}"
 


### PR DESCRIPTION
This pull request enhances the `replace_node.yml` playbook by introducing support for managing multiple Scylla Manager clusters. The changes ensure that tasks such as suspending, resuming, and repairing nodes are executed across all configured clusters, improving flexibility and scalability.

### Enhancements for multi-cluster support:

* **Task suspension and resumption**:
  - Updated the suspension and resumption tasks to loop through all configured clusters (`scylla_clusters`) instead of targeting a single cluster (`scylla_cluster_name`). This allows managing multiple clusters simultaneously. (`[[1]](diffhunk://#diff-0669256df2a7ebd6796cee2327bcdfe0fe3fbcd3354f28bad82f7d09e1e69631L142-R144)`, `[[2]](diffhunk://#diff-0669256df2a7ebd6796cee2327bcdfe0fe3fbcd3354f28bad82f7d09e1e69631L354-R357)`)

* **Cluster identification and validation**:
  - Replaced the single-cluster identification logic with a loop to check all clusters for the presence of the new node. Added validation steps to ensure the new node is managed by exactly one cluster, improving error handling and robustness. (`[example-playbooks/replace_node/replace_node.ymlL371-R394](diffhunk://#diff-0669256df2a7ebd6796cee2327bcdfe0fe3fbcd3354f28bad82f7d09e1e69631L371-R394)`)

* **Repair task update**:
  - Adjusted the repair task to use the identified cluster (`cluster_with_new_node[0]`) instead of a hardcoded cluster name, ensuring the repair operation targets the correct cluster. (`[example-playbooks/replace_node/replace_node.ymlL371-R394](diffhunk://#diff-0669256df2a7ebd6796cee2327bcdfe0fe3fbcd3354f28bad82f7d09e1e69631L371-R394)`)