### PR TITLE
main.yml: add a check to ensure scylla_version is defined

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -200,10 +200,9 @@ scylla_dependencies:
 
 # Specify a Scylla version here (should be available in repo)
 # ex: scylla_version: 2019.1.9 or 3.2.1
-# Default is intentionally invalid version - it MUST be overridden
 # 'latest' value would resolve to a current latest OSS or Enterprise version
 # according to a scylla_edition value.
-scylla_version: '0.0.0'
+# scylla_version: 'latest'
 
 # Options are oss|enterprise
 #scylla_edition: oss

--- a/ansible-scylla-node/tasks/main.yml
+++ b/ansible-scylla-node/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+# Sanity checking
+- name: Verify that 'scylla_version' is defined
+  fail:
+    msg: "scylla_version must be defined!"
+  when: scylla_version is not defined
+
 # Facts gathering
 - name: Populate service facts
   service_facts:


### PR DESCRIPTION
Explicitly verify that scylla_version is defined instead of relying on a "broken" default value.

This way, the error message is clear and the Role errors out early.