### PR TITLE
ansible-scylla-monitoring: Try nodetool status on all nodes when use_nodetool_status_with_genconfig is used

### DIFF
--- a/ansible-scylla-monitoring/tasks/common.yml
+++ b/ansible-scylla-monitoring/tasks/common.yml
@@ -88,9 +88,16 @@
 
 - name: generate scylla_servers.yml for monitoring using nodetool status
   block:
-    - command: nodetool status
-      register: nodetool_status_out
-      delegate_to: "{{ groups['scylla'][0] }}"
+    - name: Save nodetool status for the first alive node
+      include_tasks: run_nodetool_status.yml
+      loop: "{{ groups['scylla'] }}"
+      loop_control:
+        loop_var: scylla_node
+
+    - name: Fail if all nodes are down
+      fail:
+        msg: "Unable to generate scylla_servers.yml because all scylla nodes are down"
+      when: nodetool_status_out is not defined
 
     - shell: "{{ base_dir }}/genconfig.py -c {{ scylla_cluster_name }} -NS -o {{ scylla_monitoring_config_path }}/scylla_servers.yml"
       args:

--- a/ansible-scylla-monitoring/tasks/run_nodetool_status.yml
+++ b/ansible-scylla-monitoring/tasks/run_nodetool_status.yml
@@ -1,0 +1,13 @@
+---
+- name: Run nodetool status
+  shell: |
+    nodetool status
+  delegate_to: "{{ scylla_node }}"
+  register: _nodetool_status_tmp
+  ignore_errors: true
+  when: nodetool_status_out is not defined
+
+- name: Save nodetool status output
+  set_fact:
+    nodetool_status_out: "{{ _nodetool_status_tmp }}"
+  when: nodetool_status_out is not defined and _nodetool_status_tmp.rc == 0


### PR DESCRIPTION
Currently, since we are running `nodetool status` only on the first node, the task responsible for generating `scylla_servers.yml` will fail if the first node is down even if all the others are UP.
Having that in mind, let's run `nodetool status` on all nodes and then use the output of the first alive node for generating the file.