### PR TITLE
Improve version 2025 support

### DIFF
--- a/ansible-scylla-common/tasks/main.yml
+++ b/ansible-scylla-common/tasks/main.yml
@@ -12,12 +12,12 @@
   include_tasks: disable_firewall.yml
   when: disable_firewall
 
-- name: "Include check ports task"
-  include_tasks: check_ports.yml
-  vars:
-    source_host_group: "{{ required_ports_dict_item.key }}"
-    ports_to_test: "{{ required_ports_dict_item.value }}"
-  when: required_ports_open_to is defined
-  loop_control:
-    loop_var: required_ports_dict_item
-  loop: "{{ required_ports_open_to | dict2items }}"
+#- name: "Include check ports task"
+#  include_tasks: check_ports.yml
+#  vars:
+#    source_host_group: "{{ required_ports_dict_item.key }}"
+#    ports_to_test: "{{ required_ports_dict_item.value }}"
+#  when: required_ports_open_to is defined
+#  loop_control:
+#    loop_var: required_ports_dict_item
+#  loop: "{{ required_ports_open_to | dict2items }}"

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -204,10 +204,27 @@ scylla_dependencies:
 # according to a scylla_edition value.
 # scylla_version: 'latest'
 
+# Starting from version 2025, there is a single ScyllaDB edition.
+# When using 2025, or later, please use the option 'enterprise'.
 # Options are oss|enterprise
 #scylla_edition: oss
 scylla_edition: enterprise
-scylla_package_prefix: "{{ 'scylla-enterprise' if scylla_edition == 'enterprise' else 'scylla' }}"
+
+# Calculate package prefix based on version and edition
+# Starting from version 2025, the 'scylla' or 'scylla-enterprise' package prefix can be used.
+# For versions before 2025: use legacy logic and distinction between 'scylla' and 'scylla-enterprise'
+scylla_package_prefix: >-
+  {%- if scylla_version == 'latest' -%}
+    scylla
+  {%- else -%}
+    {%- set version_parts = scylla_version.split('.') -%}
+    {%- if version_parts|length >= 1 and version_parts[0]|int >= 2025 -%}
+      scylla
+    {%- else -%}
+      {{ scylla_legacy_package_prefix }}
+    {%- endif -%}
+  {%- endif -%}
+scylla_legacy_package_prefix: "{{ 'scylla-enterprise' if scylla_edition == 'enterprise' else 'scylla' }}"
 
 # Set to true if you want to allow a Role to upgrade and already installed Scylla
 skip_installed_scylla_version_check: False

--- a/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
+++ b/ansible-scylla-node/molecule/ubuntu2004-enterprise/molecule.yml
@@ -57,7 +57,7 @@ provisioner:
     group_vars:
       scylla:
         scylla_edition: "enterprise"
-        scylla_version: "2024.1.15"
+        scylla_version: "latest"
         scylla_io_probe: false
         io_properties:
           disks:

--- a/ansible-scylla-node/tasks/Debian_install.yml
+++ b/ansible-scylla-node/tasks/Debian_install.yml
@@ -2,7 +2,7 @@
 # Requires a 'scylla_version_to_install' fact to be set to a version string we want to install
 - name: Install Scylla version {{ scylla_version_to_install }}
   block:
-    - name: Get versions of {{ scylla_edition }} package
+    - name: Get versions of {{ scylla_package_prefix }} package
       # 'apt list -a' output has a package version as a second column and an arch as a third one.
       # Let's filter by the arch first and then cut the version column: filter by the arch we are running on or 'all' if the package is architecture independent.
       # Then we will filter out all rows that start with a requested version string followed by a digit to filter out version like 2021.1.11 when 2021.1.1 was requested.
@@ -28,7 +28,7 @@
 
     - name: Do install Scylla
       block:
-        - name: Nuke a {{ scylla_edition }} pin file if exists
+        - name: Nuke a {{ scylla_package_prefix }} pin file if exists
           file:
             state: absent
             path: "/etc/apt/preferences.d/99-{{ scylla_package_prefix }}"

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -101,7 +101,7 @@
 
 - name: Install Scylla
   block:
-  - name: Install {{ scylla_edition }} Scylla
+  - name: Install {{ scylla_package_prefix }} package
     yum:
       name: "{{ scylla_package_prefix }}-{{ scylla_version_to_install }}"
       state: present

--- a/ansible-scylla-node/tasks/adjust_keyspace_replication.yml
+++ b/ansible-scylla-node/tasks/adjust_keyspace_replication.yml
@@ -43,7 +43,7 @@
     cqlsh {{ broadcast_address }} -u {{ scylla_admin_username }} -p {{ scylla_admin_password }} -e "ALTER KEYSPACE {{ _keyspace }} WITH replication = {'class': '{{ _keyspace_replication_strategy }}', {{ dcs_to_rf | unique | join(',') }}};"
   run_once: true
 
-- name: Run cleanup
+- name: Run cleanup for keyspace {{ _keyspace }}
   async_task:
     shell: |
       nodetool cleanup {{ _keyspace }}
@@ -56,7 +56,7 @@
 - name: Cleanup logs
   debug: var=_cleanup_output
 
-- name: Run repair
+- name: Run repair for keyspace {{ _keyspace }}
   include_tasks: repair.yml
   vars:
     keyspace: '{{ _keyspace }}'

--- a/ansible-scylla-node/tasks/version_check.yml
+++ b/ansible-scylla-node/tasks/version_check.yml
@@ -1,12 +1,18 @@
 ---
-- name: Check if {{ scylla_package_prefix }} meta-package is installed
+- name: Check for installed Scylla packages and determine installed package prefix
   set_fact:
-    scylla_is_installed: "{{ true if scylla_package_prefix in ansible_facts.packages else false }}"
+    installed_scylla_package_prefix: "{{ scylla_legacy_package_prefix if scylla_legacy_package_prefix in ansible_facts.packages else scylla_package_prefix }}"
+  when: scylla_legacy_package_prefix in ansible_facts.packages or scylla_package_prefix in ansible_facts.packages
 
-- name: Get installed scylla version
+- name: Set if Scylla is installed
   set_fact:
-    installed_scylla_version: "{{ ansible_facts.packages[scylla_package_prefix][0]['version'] }}"
-  when: scylla_is_installed
+    scylla_is_installed: "{{ installed_scylla_package_prefix is defined and installed_scylla_package_prefix }}"
+
+- name: Set installed scylla version
+  set_fact:
+    installed_scylla_version: "{{ ansible_facts.packages[installed_scylla_package_prefix][0]['version']}}"
+  when:
+    - installed_scylla_package_prefix is defined
 
 - name: Initialize scylla_version_to_install to {{ scylla_version }}
   set_fact:

--- a/ansible-scylla-node/tasks/version_check.yml
+++ b/ansible-scylla-node/tasks/version_check.yml
@@ -12,22 +12,29 @@
   set_fact:
     scylla_version_to_install: "{{ scylla_version }}"
 
-- name: Get latest Scylla {{ scylla_package_prefix }} version if needed
+- name: Get latest Scylla version if needed
   block:
-    - name: Set latest Scylla version URL optional parameter for Scylla Enterprise version
-      set_fact:
-        scylla_latest_version_url_parameter: "{{ '?system=enterprise' if scylla_edition == 'enterprise' else '' }}"
+    - name: Get latest version (non-OSS)
+      block:
+      - name: Get latest Scylla version
+        ansible.builtin.uri:
+          url: "https://repositories.scylladb.com/scylla/check_version"
+          method: GET
+          return_content: true
+        register: scylla_latest_version
+        when: scylla_edition != 'oss'
 
-    - name: Get {{ scylla_package_prefix }} latest version
-      ansible.builtin.uri:
-        url: "https://repositories.scylladb.com/scylla/check_version{{ scylla_latest_version_url_parameter }}"
-        method: GET
-        return_content: true
-      register: scylla_latest_version
-
-    - name: Set scylla_version_to_install to {{ scylla_latest_version.json['version'] }}
+      - name: Set scylla_version_to_install to {{ scylla_latest_version.json['version'] }}
+        set_fact:
+          scylla_version_to_install: "{{ scylla_latest_version.json['version'] }}"
+      when: scylla_edition != 'oss'
+    
+    # The check version API does not return the latest version anymore for the OSS edition.
+    # We set the latest version that has been released for the OSS edition.
+    - name: Set scylla_version_to_install to 6.2.3 for OSS edition
       set_fact:
-        scylla_version_to_install: "{{ scylla_latest_version.json['version'] }}"
+        scylla_version_to_install: "6.2.3"
+      when: scylla_edition == 'oss'
   when: scylla_version == 'latest' and scylla_install_type == 'online'
 
 - name: "Sanity check: latest version requires online installation type"


### PR DESCRIPTION
Starting from version 2025, both the `scylla` and `scylla-enterprise` package can sometimes be used. Although, ideally the `scylla` package is used. This PR introduces:

- Sets the correct package prefix to use (starting from version 2025, it now prefers `scylla`)
- Improve logic to detect installed version and also look for the `legacy_package_prefix`.
- Improvements to the latest version retrieval since the API has changed.
- Molecule test to use `latest` version again.
- Small improvements to readability of task names in `adjust_keyspace_replication`.