### PR TITLE
ansible-scylla-node: only check required inter-node ports between scylla nodes

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -565,5 +565,5 @@ sysctl:
 apt_lock_timeout: 1200
 
 required_ports_open_to:
-  scylla: [9042, 9142, 7000, 7001, 19042, 19142]
+  scylla: [7000, 7001]
   scylla-monitor: [9180]


### PR DESCRIPTION
The port check included client-facing ports. 
We now check that only the required inter-node ports are open, which are 7000 and 7001.