### PR TITLE
example-playbooks/manage_users: add scylla_cql_manager user

### DIFF
--- a/example-playbooks/manage_users/vars/main.yml
+++ b/example-playbooks/manage_users/vars/main.yml
@@ -12,6 +12,12 @@ internal_users:
     superuser: false
     permissions:
       - ['SELECT', 'KEYSPACE SYSTEM']
+  scylla_cql_manager:
+    superuser: false
+    permissions:
+    - ['DESCRIBE', 'ALL ROLES']
+    - ['SELECT', 'KEYSPACE system']
+    - ['SELECT', 'KEYSPACE system_schema']
 
 # Differently from internal users, the password for customer users
 # must be defined only here, and not in the inventory.


### PR DESCRIPTION
Since version 2025.x, it is required for scylla-manager to have access to the DB in order to take a backup of the schema and roles. We create a `scylla_cql_manager` user that has minimal read-only access to this information.