### PR TITLE
ansible-scylla-common: set apt config file to prevent dpkg lock timeout

### DIFF
--- a/ansible-scylla-common/defaults/main.yml
+++ b/ansible-scylla-common/defaults/main.yml
@@ -18,3 +18,6 @@ check_ports_listener_timeout: 360
 
 # Default time-out to wait on acquiring an APT lock.
 apt_lock_timeout: 1200
+
+# Create a /etc/apt/apt.conf.d/99locktimeout file that sets the Dpkg::Lock::Timeout value
+apt_lock_create_config: false

--- a/ansible-scylla-common/tasks/main.yml
+++ b/ansible-scylla-common/tasks/main.yml
@@ -13,6 +13,9 @@
   when: disable_firewall
 
 - block:
+    - name: "Include apt configuration task"
+      include_tasks: set_apt_config.yml
+    
     - name: "Include check ports task"
       include_tasks: check_ports.yml
       vars:

--- a/ansible-scylla-common/tasks/set_apt_config.yml
+++ b/ansible-scylla-common/tasks/set_apt_config.yml
@@ -1,0 +1,10 @@
+---
+# Set apt configuration to avoid dpkg lock issues
+- name: Create the DPKG lock timeout configuration
+  copy:
+    content: 'Dpkg::Lock::Timeout "{{ apt_lock_timeout }}";'
+    dest: /etc/apt/apt.conf.d/99locktimeout
+    owner: root
+    group: root
+    mode: '0644'
+  when: apt_lock_create_config is defined and apt_lock_create_config | bool


### PR DESCRIPTION
In a previous PR (#457), we had set module defaults to increase the `apt` timeout lock. However, it seems this still doesn't prevent issues when an `unatttend-upgr` executes, which will claim a dpkg lock. This is due to a known Ansible bug in the `apt` module, which is supposedly resolved in version `2.19`. In order to workaround this issue for now, we allow an `apt` configuration file to be set which configures a timeout.

This PR introduces `apt_lock_create_config` which by default is `false`, but when enabled, it will set a configuration file for the `apt` package to wait when there is a dpkg lock.

This was tested by running `sudo unattended-upgrade` on the target machine, and with the `apt_lock_create_config` being `false` or `true`. Without such a configuration, any `apt` task will immediately fail. For example, in the case of a machine where I ran an upgrade at the same time as the playbook:

```
TASK [ansible-scylla-common : Install task dependencies] *****************************************************************************************************************************************************************************
ok: [scylla-vince-test-mngr-user-us-east1-c-1]
ok: [scylla-vince-test-mngr-user-us-east1-c-3]
fatal: [scylla-vince-test-mngr-user-us-east1-c-2]: FAILED! => {"cache_update_time": 1754906485, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'iproute2=5.5.0-1ubuntu1'' failed: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 38537 (unattended-upgr)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?\n", "rc": 100, "stderr": "E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 38537 (unattended-upgr)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?\n", "stderr_lines": ["E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 38537 (unattended-upgr)", "E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?"], "stdout": "", "stdout_lines": []}
```


However, when the configuration is present, the `apt` task will wait for the configured timeout. If the lock is released in the meantime, the `apt` task will complete.