### PR TITLE
ansible-scylla-node,ansible-scylla-monitoring: Upgrade ansible community and core package versions

### DIFF
--- a/ansible-scylla-monitoring/requirements-dev.txt
+++ b/ansible-scylla-monitoring/requirements-dev.txt
@@ -8,7 +8,7 @@ ansible-compat==2.2.7
     # via
     #   -c requirements.txt
     #   ansible-lint
-ansible-core==2.13.7
+ansible-core==2.17.14
     # via
     #   -c requirements.txt
     #   ansible-lint

--- a/ansible-scylla-monitoring/requirements.in
+++ b/ansible-scylla-monitoring/requirements.in
@@ -1,5 +1,5 @@
 # Python requirements for executing
-ansible ~=6.7.0
+ansible ~=10.5.0
 docker
 mkdocs
 molecule[docker]

--- a/ansible-scylla-monitoring/requirements.txt
+++ b/ansible-scylla-monitoring/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-ansible==6.7.0
+ansible==10.5.0
     # via -r requirements.in
 ansible-compat==2.2.7
     # via molecule
-ansible-core==2.13.7
+ansible-core==2.17.14
     # via ansible
 arrow==1.2.3
     # via jinja2-time

--- a/ansible-scylla-node/requirements-dev.txt
+++ b/ansible-scylla-node/requirements-dev.txt
@@ -8,7 +8,7 @@ ansible-compat==2.2.7
     # via
     #   -c requirements.txt
     #   ansible-lint
-ansible-core==2.13.7
+ansible-core==2.17.14
     # via
     #   -c requirements.txt
     #   ansible-lint

--- a/ansible-scylla-node/requirements.in
+++ b/ansible-scylla-node/requirements.in
@@ -1,5 +1,5 @@
 # Python requirements for executing
-ansible ~=6.7.0
+ansible ~=10.5.0
 docker
 mkdocs
 molecule[docker]

--- a/ansible-scylla-node/requirements.txt
+++ b/ansible-scylla-node/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-ansible==6.7.0
+ansible==10.5.0
     # via -r requirements.in
 ansible-compat==2.2.7
     # via molecule
-ansible-core==2.13.7
+ansible-core==2.17.14
     # via ansible
 arrow==1.2.3
     # via jinja2-time


### PR DESCRIPTION
This pull request updates the Ansible dependencies for both the `ansible-scylla-monitoring` and `ansible-scylla-node` components to use newer versions. The main focus is on upgrading `ansible` and `ansible-core` to ensure compatibility with the latest features and security patches.

Dependency updates:

* Upgraded `ansible` from version `6.7.0` to `10.5.0` in both `requirements.in` and `requirements.txt` for `ansible-scylla-monitoring` and `ansible-scylla-node`. [[1]](diffhunk://#diff-4c5e72397b8dbeb551b726992f3af82cada6fa0a3a693edfe33bbdd8c369d6e6L2-R2) [[2]](diffhunk://#diff-a76ef851c0135f2eeba1c15178c0228c8a1af57529659605ca0f093e87ba2e16L7-R11)
* Upgraded `ansible-core` from version `2.13.7` to `2.17.14` in both `requirements.txt` and `requirements-dev.txt` for `ansible-scylla-monitoring` and `ansible-scylla-node`. [[1]](diffhunk://#diff-c3cc9cf85741522979033e21caaa50ebfc7062d3fa8ba8a623b13ade85236401L11-R11) [[2]](diffhunk://#diff-a76ef851c0135f2eeba1c15178c0228c8a1af57529659605ca0f093e87ba2e16L7-R11)