### PR TITLE
Update ISSUE_TEMPLATE config to disable blank issues and redirect to Jira

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false  # Disables blank issue creation
+contact_links:
+  - name: 🚀 Press to open an issue in the Scylla Ansible Roles project in Jira.
+    url: https://scylladb.atlassian.net/jira/software/c/projects/ANSROLES/summary
+    about: "Opening issues is not allowed in this Github repository."


### PR DESCRIPTION


Blocking the ability to create issues in this GH repo, and redirecting to the relevant Jira project.