### PR TITLE
ansible-scylla-node: Validate that scylla-server is running while waiting for CQL port

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -183,7 +183,6 @@ scylla_manager_repo_keys:
   - d0a112e067426ab2
   - 5e08fbd8b5d6ec9c
   - 6B2BFD3660EF3F5B
-  - 17723034C56D4B19
   - a43e06657bac99e3
 
 

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -197,6 +197,7 @@ scylla_dependencies:
   - wget
   - python3-yaml # this will fail on non centos systems
   - nvme-cli
+  - netcat
   #- software-properties-common
   #- apt-transport-https
   #- gnupg2
@@ -211,6 +212,7 @@ scylla_redhat_dependencies:
   - policycoreutils
   - python3-pyyaml
   - nvme-cli
+  - nmap-ncat
 
 # Specify a Scylla version here (should be available in repo)
 # ex: scylla_version: 2019.1.9 or 3.2.1

--- a/ansible-scylla-node/meta/main.yml
+++ b/ansible-scylla-node/meta/main.yml
@@ -30,4 +30,5 @@ galaxy_info:
     - cassandra
 dependencies:
   - role: ansible-scylla-common
+    when: not skip_role_deps | default(false)
 

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -322,12 +322,16 @@
     - name: Start seeders serially
       run_once: true
       include_tasks: start_one_node.yml
+      vars:
+        node: "{{ item }}"
       loop: "{{ groups['scylla'] }}"
       when: hostvars[item]['broadcast_address'] in scylla_seeds or item in scylla_seeds
 
     - name: Start scylla non-seeds nodes serially
       run_once: true
       include_tasks: start_one_node.yml
+      vars:
+        node: "{{ item }}"
       loop: "{{ groups['scylla'] }}"
       when:
         - item not in scylla_seeds

--- a/ansible-scylla-node/tasks/start_one_node.yml
+++ b/ansible-scylla-node/tasks/start_one_node.yml
@@ -1,15 +1,30 @@
 ---
-- name: start scylla on {{ item }}
+- name: start scylla on {{ node }}
   service:
     name: scylla-server
     state: started
   become: true
-  delegate_to: "{{ item }}"
+  delegate_to: "{{ node }}"
 
 # By default waits at most 7 hours for a node to start - bootstrapping and the corresponding streaming can take quite long
-- name: Wait for CQL port on {{ hostvars[item]['rpc_address'] }}
-  wait_for:
-    port: 9042
-    host: "{{ hostvars[item]['rpc_address'] }}"
-    timeout: "{{ scylla_bootstrap_wait_time_sec }}"
-  delegate_to: "{{ item }}"
+- name: Wait for CQL port on {{ hostvars[node]['rpc_address'] }}
+  shell:
+    executable: /bin/bash
+    cmd: |
+      state=$(systemctl is-active scylla-server)
+
+      if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+        echo "scylla-server has unexpectedly stopped"
+        exit 1
+      fi
+
+      if nc -z -w 3 "{{ hostvars[node]['rpc_address'] }}" 9042; then
+        exit 0
+      fi
+
+      exit 2
+  register: _result
+  delegate_to: "{{ node }}"
+  until: _result.rc != 2
+  retries: "{{ scylla_bootstrap_wait_time_sec|int // 60 }}" # retries = scylla_bootstrap_wait_time_sec / (delay + nc_connect_timeout)
+  delay: 57

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -294,18 +294,15 @@
           line: "enable_repair_based_node_ops: False"
           create: yes
         when: disable_rbno|bool and _rbno_enabled is defined and _rbno_enabled|bool
-
-      - name: Start Scylla
-        service:
-          name: scylla-server
-          state: started
       when: not _scylla_running
 
-    - name: Wait for CQL port on {{ listen_address }}
-      wait_for:
-        port: "{{ cql_port }}"
-        host: "{{ listen_address }}"
-        timeout: "{{ new_node_bootstrap_wait_time_sec|int }}"
+    - name: Start new node
+      include_role:
+        name: ansible-scylla-node
+        tasks_from: start_one_node.yml
+      vars:
+        node: "{{ new_node }}"
+        skip_role_deps: true
 
     # If encryption at rest is enabled, the key will be generated during startup.
     # Let's make sure this key is stored locally as part of the metadata.

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -313,6 +313,8 @@
       include_role:
         name: ansible-scylla-node
         tasks_from: copy_system_and_table_keys.yml
+      vars:
+        skip_role_deps: true
 
     - name: Remove the replace_node_first_boot record
       lineinfile:

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -354,7 +354,7 @@
         nodetool status|grep -E '^UN'|grep -w "{{ hostvars[new_node]['broadcast_address'] }}"| wc -l
       register: node_count
       until: node_count.stdout|int == 1
-      retries: "{{ new_node_bootstrap_wait_time_sec|int }}"
+      retries: "{{ scylla_bootstrap_wait_time_sec|int }}"
       delay: 1
 
     - name: start and enable the Manager agent service

--- a/example-playbooks/replace_node/vars/main.yml
+++ b/example-playbooks/replace_node/vars/main.yml
@@ -27,14 +27,6 @@ extra_repair_params: ''
 # stopping the execution of the playbook with an error message.
 new_node_repair_timeout_seconds: 36000
 
-# Default bootstrap timeout for the new node
-# This value will be used as a timeout twice:
-#   * Once for waiting for the CQL port to become available
-#   * And then it'll also be used to wait for the node to be seen as healthy by itself and by the other nodes
-# This means that in the worst case the actual timeout for bootstrapping will be:
-# (new_node_bootstrap_wait_time_sec * (n_nodes + 1))
-new_node_bootstrap_wait_time_sec: 25200
-
 # If you set this to true, this playbook will allow you to replace an alive node
 # by draining/stopping the node being replaced before starting the replace
 alive_node_replace: false


### PR DESCRIPTION
This pull request refactors the process for starting Scylla nodes in the Ansible playbooks, focusing on improved variable handling, enhanced startup checks, and more consistent timeout management. The changes primarily streamline how nodes are started and monitored, making the playbooks more robust and easier to maintain.

Improvements to node startup and monitoring:

* Replaced the use of `item` with a dedicated `node` variable when starting nodes, ensuring clearer and more consistent variable usage across tasks and roles (`ansible-scylla-node/tasks/common.yml`, `ansible-scylla-node/tasks/start_one_node.yml`, `example-playbooks/replace_node/replace_node.yml`). [[1]](diffhunk://#diff-b6c93256c8075ca686527b80578847d5c50e8c85a714f9a41851c610152126dcR325-R334) [[2]](diffhunk://#diff-39c31111da077f316221697afd406671a386a932c56c2cb1e6a20dd1c62ddc02L2-R30) [[3]](diffhunk://#diff-0669256df2a7ebd6796cee2327bcdfe0fe3fbcd3354f28bad82f7d09e1e69631L297-R314)
* Enhanced the CQL port check by switching from the `wait_for` module to a custom shell command that also verifies the Scylla server's state, providing better error handling and more reliable startup detection (`ansible-scylla-node/tasks/start_one_node.yml`).

Timeout and dependency management:

* Unified the bootstrap timeout by removing the `new_node_bootstrap_wait_time_sec` variable and switching to `scylla_bootstrap_wait_time_sec` for all relevant operations, ensuring consistency across node replacement and startup tasks (`example-playbooks/replace_node/replace_node.yml`, `example-playbooks/replace_node/vars/main.yml`). [[1]](diffhunk://#diff-0669256df2a7ebd6796cee2327bcdfe0fe3fbcd3354f28bad82f7d09e1e69631L358-R357) [[2]](diffhunk://#diff-5ce273d3a5fa9ea724b25634719bdad94dfffce713d4b86f61c9bdcc50f1ea53L30-L37)
* Added `skip_role_deps` handling to role dependencies and included tasks, allowing for more flexible role execution and dependency skipping when desired (`ansible-scylla-node/meta/main.yml`, `example-playbooks/replace_node/replace_node.yml`). [[1]](diffhunk://#diff-1791552ae8392bf97da2377fd3bab65917430fe5dcd760264a3d50c3f5549ef7R33) [[2]](diffhunk://#diff-0669256df2a7ebd6796cee2327bcdfe0fe3fbcd3354f28bad82f7d09e1e69631L297-R314)

These changes collectively make the playbooks more robust, readable, and maintainable.

Fixes https://github.com/scylladb/scylla-ansible-roles/issues/462