### PR TITLE
ansible-scylla-common: dpkg set timeout using become flag

### DIFF
--- a/ansible-scylla-common/defaults/main.yml
+++ b/ansible-scylla-common/defaults/main.yml
@@ -22,4 +22,4 @@ check_ports_client_timeout_sec: 120
 apt_lock_timeout: 1200
 
 # Create a /etc/apt/apt.conf.d/99locktimeout file that sets the Dpkg::Lock::Timeout value
-apt_lock_create_config: false
+apt_lock_create_config: true

--- a/ansible-scylla-common/tasks/set_apt_config.yml
+++ b/ansible-scylla-common/tasks/set_apt_config.yml
@@ -1,6 +1,7 @@
 ---
 # Set apt configuration to avoid dpkg lock issues
 - name: Create the DPKG lock timeout configuration
+  become: true
   copy:
     content: 'Dpkg::Lock::Timeout "{{ apt_lock_timeout }}";'
     dest: /etc/apt/apt.conf.d/99locktimeout


### PR DESCRIPTION
We need root privileges in order to be able to write the apt configuration.