### PR TITLE
ansible-scylla-node: Remove stale scylla apt source files before repo setup and drop duplicated upgrade code

### DIFF
--- a/ansible-scylla-common/defaults/main.yml
+++ b/ansible-scylla-common/defaults/main.yml
@@ -18,6 +18,12 @@ check_ports_listener_timeout_sec: 360
 # Default timeout when trying to reach a port on another node
 check_ports_client_timeout_sec: 120
 
+# Glob patterns (shell-style filenames) for .list files under /etc/apt/sources.list.d.
+# At the start of the Debian path in this role, any file whose name matches a pattern is
+# removed so a later apt update does not hit broken or stale third-party sources;
+# roles that run afterward are expected to recreate the repos and keys they need.
+# repo_pattern_list: []
+
 # Default time-out to wait on acquiring an APT lock.
 apt_lock_timeout: 1200
 

--- a/ansible-scylla-common/tasks/Debian_tasks.yml
+++ b/ansible-scylla-common/tasks/Debian_tasks.yml
@@ -1,3 +1,7 @@
 ---
+- name: Remove stale apt repositories before refresh
+  ansible.builtin.include_tasks: cleanup_stale_repos.yml
+  when: repo_pattern_list | default([]) | length > 0
+
 - name: "Include apt configuration task"
   include_tasks: set_apt_config.yml

--- a/ansible-scylla-common/tasks/cleanup_stale_repos.yml
+++ b/ansible-scylla-common/tasks/cleanup_stale_repos.yml
@@ -1,0 +1,15 @@
+---
+# Debian/Ubuntu only: remove matching files under /etc/apt/sources.list.d before apt update.
+- name: Find matching apt list files under /etc/apt/sources.list.d
+  ansible.builtin.find:
+    paths: /etc/apt/sources.list.d
+    patterns: "{{ repo_pattern_list }}"
+    file_type: file
+  register: scylla_stale_apt_repo_files
+
+- name: Remove stale apt source files
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  become: true
+  loop: "{{ scylla_stale_apt_repo_files.files }}"

--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -55,5 +55,8 @@ enable_upgrade: false
 # Default time-out to wait on acquiring an APT lock.
 apt_lock_timeout: 1200
 
+repo_pattern_list:
+  - "scylla*"
+
 required_ports_open_to:
   scylla-monitor: [5090]

--- a/ansible-scylla-monitoring/defaults/main.yml
+++ b/ansible-scylla-monitoring/defaults/main.yml
@@ -98,6 +98,9 @@ prometheus_url: 'https://github.com/prometheus/prometheus/releases/download/v2.3
 # The content of this variable will be coppied to /etc/docker/daemon.json
 # docker_daemon_custom_config: { "bip": "172.17.0.1/24" }
 
+repo_pattern_list:
+  - "*docker*"
+
 # Default time-out to wait on acquiring an APT lock.
 apt_lock_timeout: 1200
 

--- a/ansible-scylla-monitoring/tasks/Debian.yml
+++ b/ansible-scylla-monitoring/tasks/Debian.yml
@@ -39,8 +39,10 @@
       state: present
 
   - name: add repo
-    shell: |
-      sudo add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+    ansible.builtin.apt_repository:
+      repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+      filename: docker
+      state: present
 
   - name: Update apt cache
     apt:

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -593,6 +593,9 @@ sysctl:
 # Default time-out to wait on acquiring an APT lock.
 apt_lock_timeout: 1200
 
+repo_pattern_list:
+  - "scylla*"
+
 required_ports_open_to:
   scylla: [7000, 7001]
   scylla-monitor: [9180]

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -81,6 +81,7 @@
       name: openjdk-8-jre-headless
       state: present
       force_apt_get: yes
+    when: ansible_facts['distribution']|lower == 'ubuntu'
 
   - name: Install Scylla packages
     include_tasks: Debian_install.yml

--- a/ansible-scylla-node/tasks/upgrade/upgrade_debian.yml
+++ b/ansible-scylla-node/tasks/upgrade/upgrade_debian.yml
@@ -7,43 +7,11 @@
     state: present
   become: true
 
-
-# Add Scylla apt key
-- name: Add Scylla apt key
-  ansible.builtin.apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: 5e08fbd8b5d6ec9c
-  become: true
-
-- name: Add Scylla apt key
-  ansible.builtin.apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: D0A112E067426AB2
-  become: true
-
-# Remove existing Scylla repositories
-- name: Remove existing Scylla repositories
-  ansible.builtin.file:
-    path: /etc/apt/sources.list.d/scylla.list
-    state: absent    
-  become: true
-
-
-# Create Scylla repositories file
-- name: Create Scylla repositories file
-  ansible.builtin.get_url:
-    url: "https://downloads.scylladb.com/deb/debian/scylla-{{ scylla_upgrade['major_version'] }}.list"
-    dest: /etc/apt/sources.list.d/scylla.list
-    mode: '0644'
-  become: true
-
-
 # Unhold Scylla package in case it's marked as 'hold'
 - name: Unhold package name {{ scylla_detected['package_name'] }}*
   ansible.builtin.dpkg_selections:
     name: "{{ scylla_detected['package_name'] }}*"
     selection: install
-
 
 # Upgrade Scylla
 - name: "Upgrade Scylla to {{ scylla_upgrade['version'] }}"
@@ -51,4 +19,4 @@
     scylla_version_to_install: "{{ scylla_upgrade['version'] }}"
 
 - name: Install Scylla packages
-  include_tasks: ../Debian_install.yml
+  include_tasks: ../Debian.yml

--- a/ansible-scylla-node/tasks/upgrade/upgrade_ubuntu.yml
+++ b/ansible-scylla-node/tasks/upgrade/upgrade_ubuntu.yml
@@ -7,47 +7,11 @@
     state: present
   become: true
 
-
-# Add Scylla apt key
-- name: Add Scylla apt key
-  ansible.builtin.apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: 5e08fbd8b5d6ec9c
-  become: true
-
-- name: Add Scylla apt key
-  ansible.builtin.apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: D0A112E067426AB2
-  become: true
-
-# Remove existing Scylla repositories
-- name: Remove existing Scylla repositories
-  ansible.builtin.file:
-    path: /etc/apt/sources.list.d/scylla.list
-    state: absent    
-  become: true
-
-
-# Create Scylla repositories file
-- name: Create Scylla repositories file
-  ansible.builtin.get_url:
-    url: "https://downloads.scylladb.com/deb/ubuntu/scylla-{{ scylla_upgrade['major_version'] }}.list"
-    dest: /etc/apt/sources.list.d/scylla.list
-    mode: '0644'
-  become: true
-
-- name: Run "apt-get update"
-  apt:
-    update_cache: yes
-  become: true  
-
 # Unhold Scylla package in case it's marked as 'hold'
 - name: Unhold Scylla package
   ansible.builtin.dpkg_selections:
     name: "{{ scylla_detected['package_name'] }}*"
     selection: install
-
 
 # Upgrade Scylla
 - name: "Upgrade Scylla to {{ scylla_upgrade['version'] }}"
@@ -55,4 +19,4 @@
     scylla_version_to_install: "{{ scylla_upgrade['version'] }}"
 
 - name: Install Scylla packages
-  include_tasks: ../Debian_install.yml
+  include_tasks: ../Debian.yml


### PR DESCRIPTION
This pull request introduces a new mechanism for cleaning up stale or broken APT repositories before running package operations on Debian/Ubuntu systems. It does so by adding configurable glob patterns for repository file cleanup, integrating this cleanup step into the playbooks, and simplifying repository management. The changes also improve Ansible best practices by replacing shell commands with native modules and removing redundant tasks.

Key changes include:

**Repository Cleanup Mechanism:**

* Added a new variable `repo_pattern_list` (with default patterns in relevant roles) to specify glob patterns for `.list` files under `/etc/apt/sources.list.d` that should be removed before running APT operations, preventing issues with stale or broken repositories. (`ansible-scylla-common/defaults/main.yml`, `ansible-scylla-manager/defaults/main.yml`, `ansible-scylla-monitoring/defaults/main.yml`, `ansible-scylla-node/defaults/main.yml`) [[1]](diffhunk://#diff-131eaf5cb57ad6541fa6893c7a719420f59181dcaea5ca5ade2f960d6a2ff9a9R21-R26) [[2]](diffhunk://#diff-24344c2842b4ea1bdbf6c60a2a6043a71eca4b9f6810081738d2dd78aaf07ad9R58-R60) [[3]](diffhunk://#diff-610bf15fd475a2628bc1cb5d3090a5a98db4d7535854f8d001210c1c183aff69R101-R103) [[4]](diffhunk://#diff-20829e5f73bbd6db3dff12e61bd63ef7f7b3daa0b647bb4b0a34b0dbb05ba6c6R596-R598)
* Implemented a new task file `cleanup_stale_repos.yml` that finds and removes matching repository files based on `repo_pattern_list`, and included this task at the start of Debian package management workflows. (`ansible-scylla-common/tasks/cleanup_stale_repos.yml`, `ansible-scylla-common/tasks/Debian_tasks.yml`) [[1]](diffhunk://#diff-21b41b7ce38883dc32fcd2769cd40eb43dfed80a121a2cca263b8529170702dbR1-R15) [[2]](diffhunk://#diff-1e87910b38a16aa4a67070b623d713d37dd518d0de8dfeabb030b86e3112cf1fR2-R5)

**Repository Management Simplification:**

* Removed manual steps for adding/removing Scylla APT keys and repository files from the upgrade tasks, relying instead on the new cleanup mechanism and standard install tasks to recreate necessary repositories. (`ansible-scylla-node/tasks/upgrade/upgrade_debian.yml`, `ansible-scylla-node/tasks/upgrade/upgrade_ubuntu.yml`) [[1]](diffhunk://#diff-41d8472eb7d2b5b6fd458100b6b12ab9d001a6e259bf99c78078802f003c6ae2L10-R22) [[2]](diffhunk://#diff-40b81fce494aabb0e7dd615c668183cb4631f664ca5821062fa5feefa385e3bbL10-R22)
* Changed the Docker repository addition to use the `apt_repository` Ansible module instead of a shell command, improving idempotency and clarity. (`ansible-scylla-monitoring/tasks/Debian.yml`)

**Other Improvements:**

* Fixed a conditional to ensure OpenJDK is only installed on Ubuntu. (`ansible-scylla-node/tasks/Debian.yml`)

These changes make repository management more robust, reduce the risk of APT failures due to stale sources, and align the playbooks with Ansible best practices.