### PR TITLE
Add a generic support for removing conflicting packages and remove google-guest-agent by default

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -213,6 +213,13 @@ scylla_redhat_dependencies:
   - python3-pyyaml
   - nvme-cli
 
+#debian_packages_to_remove:
+#  - google-guest-agent
+
+redhat_packages_to_remove:
+  - abrt
+#  - google-guest-agent
+
 # Specify a Scylla version here (should be available in repo)
 # ex: scylla_version: 2019.1.9 or 3.2.1
 # 'latest' value would resolve to a current latest OSS or Enterprise version

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -213,12 +213,12 @@ scylla_redhat_dependencies:
   - python3-pyyaml
   - nvme-cli
 
-#debian_packages_to_remove:
-#  - google-guest-agent
+debian_packages_to_remove:
+  - google-guest-agent
 
 redhat_packages_to_remove:
   - abrt
-#  - google-guest-agent
+  - google-guest-agent
 
 # Specify a Scylla version here (should be available in repo)
 # ex: scylla_version: 2019.1.9 or 3.2.1

--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -82,6 +82,13 @@
       state: present
       force_apt_get: yes
 
+  - name: Remove conflicting packages
+    apt:
+      name: "{{ debian_packages_to_remove }}"
+      state: absent
+      force_apt_get: yes
+    when: debian_packages_to_remove is defined and (debian_packages_to_remove|length > 0)
+
   - name: Install Scylla packages
     include_tasks: Debian_install.yml
   become: true

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -66,11 +66,12 @@
   when: elrepo_kernel|bool and scylla_install_type == 'online' and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
   become: true
 
-- name: remove abrt
+- name: Remove conflicting packages
   package:
-    name: abrt
+    name: "{{ redhat_packages_to_remove }}"
     state: absent
   become: true
+  when: redhat_packages_to_remove is defined and redhat_packages_to_remove|length > 0
 
 - name: Install Scylla repo
   get_url:


### PR DESCRIPTION
This pull request updates the Ansible playbooks for Scylla node deployment to improve package management by ensuring that conflicting or unnecessary packages are removed before installation. The main changes introduce configurable lists of packages to remove for both Debian and RedHat-based systems and update the tasks to use these lists.

**Improvements to package removal and configuration:**

* Added `debian_packages_to_remove` and `redhat_packages_to_remove` variables in `defaults/main.yml` to specify packages that should be removed on Debian and RedHat systems, respectively. Notably, `google-guest-agent` is now removed on both platforms, and `abrt` is removed on RedHat.
* Updated `tasks/Debian.yml` to remove all packages listed in `debian_packages_to_remove` using a single task, making the process more maintainable and consistent.
* Updated `tasks/RedHat.yml` to remove all packages listed in `redhat_packages_to_remove` in one task, generalizing the previous removal of only `abrt` and adding support for removing `google-guest-agent`.