### PR TITLE
ansible-scylla-monitoring: Set cluster label for Prometheus in scylla_manager_servers.yml

### DIFF
--- a/ansible-scylla-monitoring/tasks/common.yml
+++ b/ansible-scylla-monitoring/tasks/common.yml
@@ -154,7 +154,9 @@
 - name: set up scylla_manager_servers.yml
   copy:
     content: |
-      - targets:
+      - labels:
+          cluster: {{ scylla_cluster_name }}
+        targets:
         - {{ _scylla_manager_target|default('172.17.0.1') }}:5090
     dest: "{{ scylla_monitoring_config_path }}/scylla_manager_servers.yml"
     mode: '0644'


### PR DESCRIPTION
This pull request updates the configuration for Scylla Manager monitoring to include cluster labeling for improved service discovery and organization.

Configuration improvements:

* [`ansible-scylla-monitoring/tasks/common.yml`](diffhunk://#diff-d910f08594d27686bb2fe4cc7fa438901009dbb41d7fd524d3e84f947d82b440L157-R159): Modified the `scylla_manager_servers.yml` setup to add a `labels` section (including the `cluster` name) alongside the `targets` list. This change helps Prometheus and other monitoring tools to better organize and filter targets by cluster.