### PR TITLE
 ansible-scylla-common: Replace port lists with ip/port tuples in `required_ports_open_to`

### DIFF
--- a/ansible-scylla-common/defaults/main.yml
+++ b/ansible-scylla-common/defaults/main.yml
@@ -5,13 +5,19 @@
 # When the deprecated variable `firewall_enabled` is present, and when this is false, the firewall will be deactivated.
 disable_firewall: "{{ not (firewall_enabled | default(false)) }}"
 
-# A dictionary that defines which TCP ports must be reachable on the node(s) targeted by this role.
+# A dictionary that defines which TCP addresses (IP or DNS) and ports must be reachable on the node(s) targeted by this role.
 # The dictionary is keyed by the name of the source group.
 # For each source group, the role will test connectivity by attempting to establish a TCP connection
-# from each host in the group to the current host on the listed ports.
+# from each host in the group to the current host on the list.
 # required_ports_open_to:
-#   group_1: []
-#   group_2: []
+#   group_1:
+#     - address: 1.2.3.4
+#       port: 8000
+#   group_2:
+#     - address: 1.2.3.5
+#       port: 8001
+#     - address: 1.2.3.5
+#       port: 8002
 #
 # Default duration that listeners used for testing required ports should stay alive
 check_ports_listener_timeout_sec: 360

--- a/ansible-scylla-common/tasks/check_ports.yml
+++ b/ansible-scylla-common/tasks/check_ports.yml
@@ -13,9 +13,7 @@
 
 - name: Create temporary listeners on required ports, if needed
   shell: |
-    if ! ss -ltn | awk '{print $4}' | grep -q "^{{ address }}:{{ port }}$"; then
-      timeout {{ check_ports_listener_timeout_sec | int }} socat TCP-LISTEN:{{ port }},bind={{ address }},fork EXEC:'/bin/true'
-    fi
+    timeout {{ check_ports_listener_timeout_sec | int }} socat TCP-LISTEN:{{ port }},bind={{ address }},fork EXEC:'/bin/true'
   loop: "{{ ports_to_test }}"
   vars:
     address: "{{ item.address }}"

--- a/ansible-scylla-common/tasks/check_ports.yml
+++ b/ansible-scylla-common/tasks/check_ports.yml
@@ -13,30 +13,30 @@
 
 - name: Create temporary listeners on required ports, if needed
   shell: |
-    if ! ss -ltn | awk '{print $4}' | grep -q ":{{ port }}$"; then
-      timeout {{ check_ports_listener_timeout_sec | int }} socat TCP-LISTEN:{{ port }},fork EXEC:'/bin/true'
+    if ! ss -ltn | awk '{print $4}' | grep -q "^{{ address }}:{{ port }}$"; then
+      timeout {{ check_ports_listener_timeout_sec | int }} socat TCP-LISTEN:{{ port }},bind={{ address }},fork EXEC:'/bin/true'
     fi
   loop: "{{ ports_to_test }}"
-  loop_control:
-    loop_var: port
+  vars:
+    address: "{{ item.address }}"
+    port: "{{ item.port }}"
   async: "{{ (check_ports_listener_timeout_sec | int) + 10 }}"
   poll: 0
 
 - name: Validate that the listeners are ready to accept connections before testing cross-host connectivity
   wait_for:
-    host: "{{ ansible_host | default(inventory_hostname) }}"
-    port: "{{ item }}"
+    host: "{{ item.address }}"
+    port: "{{ item.port | int }}"
     timeout: "{{ check_ports_client_timeout_sec | int }}"
     state: started
   loop: "{{ ports_to_test }}"
 
 - name: Check if necessary ports are reachable from host group {{ source_host_group }}
   wait_for:
-    host: "{{ hostvars[inventory_hostname]['ansible_host'] | default(inventory_hostname) }}"
-    port: "{{ item[1] }}"
+    host: "{{ item[1].address }}"
+    port: "{{ item[1].port | int }}"
     timeout: "{{ check_ports_client_timeout_sec | int }}"
     state: started
-  when: item[0] != inventory_hostname
   delegate_to: "{{ item[0] }}"
   loop: "{{ groups[source_host_group] | default([]) | product(ports_to_test) | list }}"
 

--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -51,12 +51,3 @@ enable_upgrade: false
 #     auth_token_file: /path/to/filewithtoken
 #     without_repair: false
 #     host: 1.2.3.4
-
-# Default time-out to wait on acquiring an APT lock.
-apt_lock_timeout: 1200
-
-repo_pattern_list:
-  - "scylla*"
-
-required_ports_open_to:
-  scylla-monitor: [5090]

--- a/ansible-scylla-manager/meta/main.yml
+++ b/ansible-scylla-manager/meta/main.yml
@@ -26,6 +26,13 @@ galaxy_info:
 
 dependencies:
   - role: "ansible-scylla-common"
+    vars:
+      # Default time-out to wait on acquiring an APT lock.
+      apt_lock_timeout: 1200
+      repo_pattern_list:
+        - "scylla*"
+      required_ports_open_to:
+        scylla-monitor: [5090]
   - role: "ansible-scylla-node"
     vars:
       install_only: true

--- a/ansible-scylla-manager/meta/main.yml
+++ b/ansible-scylla-manager/meta/main.yml
@@ -35,6 +35,11 @@ dependencies:
         scylla-monitor:
           - address: "{{ ansible_host | default(ansible_default_ipv4.address) }}"
             port: 5090
+        scylla-manager:
+          - address: "127.0.0.1"
+            port: 7000
+          - address: "127.0.0.1"
+            port: 9042
   - role: "ansible-scylla-node"
     vars:
       install_only: true

--- a/ansible-scylla-manager/meta/main.yml
+++ b/ansible-scylla-manager/meta/main.yml
@@ -32,7 +32,9 @@ dependencies:
       repo_pattern_list:
         - "scylla*"
       required_ports_open_to:
-        scylla-monitor: [5090]
+        scylla-monitor:
+          - address: "{{ ansible_host | default(ansible_default_ipv4.address) }}"
+            port: 5090
   - role: "ansible-scylla-node"
     vars:
       install_only: true

--- a/ansible-scylla-monitoring/defaults/main.yml
+++ b/ansible-scylla-monitoring/defaults/main.yml
@@ -98,12 +98,6 @@ prometheus_url: 'https://github.com/prometheus/prometheus/releases/download/v2.3
 # The content of this variable will be coppied to /etc/docker/daemon.json
 # docker_daemon_custom_config: { "bip": "172.17.0.1/24" }
 
-repo_pattern_list:
-  - "*docker*"
-
-# Default time-out to wait on acquiring an APT lock.
-apt_lock_timeout: 1200
-
 # Set 'grafana_enable_https' to true for enabling HTTPS for Grafana.
 # If the specified certificate and key files are not found on the localhost,
 # a self-signed certificate will be generated at the provided paths.

--- a/ansible-scylla-monitoring/meta/main.yml
+++ b/ansible-scylla-monitoring/meta/main.yml
@@ -28,3 +28,8 @@ galaxy_info:
 
 dependencies:
   - role: ansible-scylla-common
+    vars:
+      repo_pattern_list:
+        - "*docker*"
+      # Default time-out to wait on acquiring an APT lock.
+      apt_lock_timeout: 1200

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -599,13 +599,3 @@ sysctl:
 # Scylla Node Exported configuration that will be configured in the corresponding EnvFile. If not defined the default
 # scylla-node-exporter/scylla-enterprise-node-exporter package configuration will be used.
 # scylla_node_exporter_params: "--collector.interrupts --collector.netdev.address-info"
-
-# Default time-out to wait on acquiring an APT lock.
-apt_lock_timeout: 1200
-
-repo_pattern_list:
-  - "scylla*"
-
-required_ports_open_to:
-  scylla: [7000, 7001]
-  scylla-monitor: [9180]

--- a/ansible-scylla-node/meta/main.yml
+++ b/ansible-scylla-node/meta/main.yml
@@ -36,7 +36,13 @@ dependencies:
       repo_pattern_list:
         - "scylla*"
       required_ports_open_to:
-        scylla: [7000, 7001]
-        scylla-monitor: [9180]
+        scylla:
+          - address: "{{ ansible_host | default(ansible_default_ipv4.address) }}"
+            port: 7000
+          - address: "{{ ansible_host | default(ansible_default_ipv4.address) }}"
+            port: 7001
+        scylla-monitor:
+          - address: "{{ ansible_host | default(ansible_default_ipv4.address) }}"
+            port: 9180
     when: not skip_role_deps | default(false)
 

--- a/ansible-scylla-node/meta/main.yml
+++ b/ansible-scylla-node/meta/main.yml
@@ -30,5 +30,13 @@ galaxy_info:
     - cassandra
 dependencies:
   - role: ansible-scylla-common
+    vars:
+      # Default time-out to wait on acquiring an APT lock.
+      apt_lock_timeout: 1200
+      repo_pattern_list:
+        - "scylla*"
+      required_ports_open_to:
+        scylla: [7000, 7001]
+        scylla-monitor: [9180]
     when: not skip_role_deps | default(false)
 

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -55,6 +55,7 @@ platforms:
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
+      - /sys/kernel/security:/sys/kernel/security:ro # Prevent container from modifying host AppArmor profile
       - /var/lib/docker # https://github.com/docker/for-linux/issues/1138
     groups:
       - scylla-monitor


### PR DESCRIPTION
This pull request updates the way required TCP ports are specified and checked in the Ansible roles for Scylla, moving from a port-only approach to an explicit IP and port structure. It also refactors how common configuration variables are managed and passed between roles, centralizing and clarifying their usage. The changes improve flexibility and clarity for connectivity checks and configuration management.

**Connectivity Check Improvements:**

* Changed the `required_ports_open_to` variable from a list of ports to a list of dictionaries specifying both `ip` and `port`, allowing more granular and explicit connectivity requirements.
* Updated the port listener and connectivity check tasks in `check_ports.yml` to use both `ip` and `port`, ensuring listeners bind to the correct address and connectivity is validated per IP/port pair.

**Configuration Management Refactoring:**

* Removed default definitions of `apt_lock_timeout`, `repo_pattern_list`, and `required_ports_open_to` from individual role defaults (`ansible-scylla-manager`, `ansible-scylla-monitoring`, `ansible-scylla-node`) and moved their assignment to the role dependencies in `meta/main.yml`, centralizing configuration and reducing duplication. [[1]](diffhunk://#diff-24344c2842b4ea1bdbf6c60a2a6043a71eca4b9f6810081738d2dd78aaf07ad9L54-L62) [[2]](diffhunk://#diff-610bf15fd475a2628bc1cb5d3090a5a98db4d7535854f8d001210c1c183aff69L101-L106) [[3]](diffhunk://#diff-20829e5f73bbd6db3dff12e61bd63ef7f7b3daa0b647bb4b0a34b0dbb05ba6c6L602-L611)
* Explicitly set role variables for dependencies in the `meta/main.yml` files for `ansible-scylla-manager`, `ansible-scylla-monitoring`, and `ansible-scylla-node`, ensuring that common configuration is consistently and correctly passed to `ansible-scylla-common`. [[1]](diffhunk://#diff-8c5a41795ce359e665fa5201923a6753fd9f92a67f4a7dcf2f7456d738a3fbecR29-R42) [[2]](diffhunk://#diff-780bd9228577abc9a4da89a1b40e60297c527cb89c017e93ceff4f344b744d6bR31-R35) [[3]](diffhunk://#diff-1791552ae8392bf97da2377fd3bab65917430fe5dcd760264a3d50c3f5549ef7R33-R46)