### PR TITLE
ansible-scylla-monitoring: Update the Monitor deployment to support arm64 architecture

### DIFF
--- a/ansible-scylla-monitoring/tasks/Debian.yml
+++ b/ansible-scylla-monitoring/tasks/Debian.yml
@@ -40,7 +40,7 @@
 
   - name: add repo
     ansible.builtin.apt_repository:
-      repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+      repo: "deb [arch={{ ansible_architecture | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
       filename: docker
       state: present
 


### PR DESCRIPTION
This PR addresses the Scylla Monitor deployment failure on an ARM based VM. 