### PR TITLE
Fail fast when scylla-server stops during bootstrap health waits

### DIFF
--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -344,13 +344,28 @@
         timeout: 300
 
     - name: wait for the cluster to become healthy
-      shell: |
-        nodetool status|grep -E '^UN|^UJ|^DN'|wc -l
+      shell:
+        executable: /bin/bash
+        cmd: |
+          state=$(systemctl is-active scylla-server)
+
+          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+            echo "scylla-server has unexpectedly stopped"
+            exit 1
+          fi
+
+          count=$(nodetool status | grep -E '^UN|^UJ|^DN' | wc -l)
+          if [[ "$count" == "{{ ansible_play_batch|length }}" ]]; then
+            exit 0
+          fi
+
+          exit 2
       register: node_count
-      until: node_count.stdout|int == ansible_play_batch|length
+      until: node_count.rc != 2
       retries: "{{ scylla_bootstrap_wait_time_sec|int }}"
       delay: 1
       when: full_inventory|bool
+      become: true
 
     - name: check API access
       uri:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -349,8 +349,8 @@
         cmd: |
           state=$(systemctl is-active scylla-server)
 
-          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-            echo "scylla-server has unexpectedly stopped"
+          if [[ "$state" != "active" && "$state" != "activating" ]]; then
+            echo "scylla-server is not running (state: $state)"
             exit 1
           fi
 

--- a/ansible-scylla-node/tasks/start_one_node.yml
+++ b/ansible-scylla-node/tasks/start_one_node.yml
@@ -13,8 +13,8 @@
     cmd: |
       state=$(systemctl is-active scylla-server)
 
-      if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-        echo "scylla-server has unexpectedly stopped"
+      if [[ "$state" != "active" && "$state" != "activating" ]]; then
+        echo "scylla-server is not running (state: $state)"
         exit 1
       fi
 

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -355,8 +355,8 @@
         cmd: |
           state=$(systemctl is-active scylla-server)
 
-          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-            echo "scylla-server has unexpectedly stopped"
+          if [[ "$state" != "active" && "$state" != "activating" ]]; then
+            echo "scylla-server is not running (state: $state)"
             exit 1
           fi
 

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -350,12 +350,29 @@
     - vars/main.yml
   tasks:
     - name: Wait for the added node to become healthy
-      shell: |
-        nodetool status|grep -E '^UN'|grep -w "{{ hostvars[new_node]['broadcast_address'] }}"| wc -l
+      shell:
+        executable: /bin/bash
+        cmd: |
+          state=$(systemctl is-active scylla-server)
+
+          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+            echo "scylla-server has unexpectedly stopped"
+            exit 1
+          fi
+
+          count=$(nodetool status | grep -E '^UN' | grep -w "{{ hostvars[new_node]['broadcast_address'] }}" | wc -l)
+          if [[ "$count" == "1" ]]; then
+            exit 0
+          fi
+
+          exit 2
       register: node_count
-      until: node_count.stdout|int == 1
+      delegate_to: "{{ new_node }}"
+      run_once: true
+      until: node_count.rc != 2
       retries: "{{ scylla_bootstrap_wait_time_sec|int }}"
       delay: 1
+      become: true
 
     - name: start and enable the Manager agent service
       service:


### PR DESCRIPTION
## Summary
- Check `systemctl is-active scylla-server` while polling nodetool during cluster health wait in the node role
- Apply the same fail-fast pattern to replace_node UN health wait (delegate to new node)
- Matches the existing CQL wait logic in `start_one_node.yml` (PR #508)

Fixes scylladb/field-engineering#2109

## Test plan
- [ ] Replace_node: simulate mid-bootstrap scylla crash; job fails immediately instead of waiting full timeout
- [ ] Create_cluster / Add_new_nodes: cluster health wait fails fast if a node dies during bootstrap
- [ ] Normal bootstrap still succeeds when scylla reaches UN


Made with [Cursor](https://cursor.com)