### PR TITLE
Support multiple inventories and --limit

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -93,7 +93,7 @@ install_only: false
 # Change here or override in vars
 scylla_nic: "{{ ansible_default_ipv4.interface }}"
 
-cluster_local_files_path: "{{ inventory_dir }}"
+manager_local_files_path: "{{ playbook_dir }}"
 
 # online|offline - offline will disable all the attepts to download packages
 # node_exporter will need to be installed manually
@@ -318,10 +318,10 @@ scylla_yaml_params:
 # You should use the 'ssl_*' vars instead.
 #
 # scylla_ssl:
-#   localhost_cert_path: "{{ inventory_dir }}/ssl/scylla.crt"
-#   localhost_cert_key_path: "{{ inventory_dir }}/scylla.pem"
-#   localhost_truststore_path: "{{ inventory_dir }}/ssl/truststore.crt"
-#   localhost_ca_cert_path: "{{ inventory_dir }}/ssl/ca/"
+#   localhost_cert_path: "{{ playbook_dir }}/ssl/scylla.crt"
+#   localhost_cert_key_path: "{{ playbook_dir }}/scylla.pem"
+#   localhost_truststore_path: "{{ playbook_dir }}/ssl/truststore.crt"
+#   localhost_ca_cert_path: "{{ playbook_dir }}/ssl/ca/"
 #   cert_path: /etc/scylla
 #   internode:
 #     enabled: true
@@ -337,10 +337,10 @@ ssl_client_enabled: "{{ (scylla_ssl | default({})).client.enabled | default(true
 # certificates and keys will be stored before being copied to the target nodes.
 # The role will automatically generate the certificates and keys and store them at these paths.
 # Alternatively, you can provide your own certificates, and the role will use those instead of generating new ones.
-ssl_localhost_cert_path: "{{ (scylla_ssl | default({})).localhost_cert_path | default(inventory_dir + '/ssl/' + inventory_hostname + '/' + inventory_hostname + '.crt') }}"
-ssl_localhost_cert_key_path: "{{ (scylla_ssl | default({})).localhost_cert_key_path | default(inventory_dir + '/ssl/' + inventory_hostname + '/' + inventory_hostname + '.pem') }}"
-ssl_localhost_ca_path: "{{ inventory_dir }}/ssl/ca/{{ scylla_cluster_name }}-ca.crt"
-ssl_localhost_ca_key_path: "{{ inventory_dir }}/ssl/ca/{{ scylla_cluster_name }}-ca.pem"
+ssl_localhost_cert_path: "{{ (scylla_ssl | default({})).localhost_cert_path | default(playbook_dir + '/ssl/' + inventory_hostname + '/' + inventory_hostname + '.crt') }}"
+ssl_localhost_cert_key_path: "{{ (scylla_ssl | default({})).localhost_cert_key_path | default(playbook_dir + '/ssl/' + inventory_hostname + '/' + inventory_hostname + '.pem') }}"
+ssl_localhost_ca_path: "{{ playbook_dir }}/ssl/ca/{{ scylla_cluster_name }}-ca.crt"
+ssl_localhost_ca_key_path: "{{ playbook_dir }}/ssl/ca/{{ scylla_cluster_name }}-ca.pem"
 ssl_localhost_truststore_path: "{{ (scylla_ssl | default({})).localhost_truststore_path | default(ssl_localhost_ca_path) }}"
 
 # Defines whether the node certificates and keys should be regenerated or not
@@ -381,7 +381,7 @@ ssl_truststore_path: "{{ (scylla_ssl | default({})).cert_path | default (ssl_cer
 # Note that by default the {{ inventory_hostname }} is part of the localhost_system_key_directory. This allows you to define
 # different keys per host.
 # e.g.:
-# If your localhost_system_key_directory is set to "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/system_encryption_keys"
+# If your localhost_system_key_directory is set to "{{ playbook_dir }}/encryption_at_rest/{{ inventory_hostname }}/system_encryption_keys"
 # and you have the following file tree:
 #
 # ├── encryption_at_rest
@@ -401,7 +401,7 @@ ssl_truststore_path: "{{ (scylla_ssl | default({})).cert_path | default (ssl_cer
 # without the {{ inventory_hostname }} in it or simply copy the same key for all the node folders.
 
 handle_system_keys: false
-localhost_system_key_directory: "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/system_encryption_keys"
+localhost_system_key_directory: "{{ playbook_dir }}/encryption_at_rest/{{ inventory_hostname }}/system_encryption_keys"
 system_key_directory: "/etc/scylla/system_encryption_keys"
 
 # Table keys are used for encrypting SSTables. Depending on your key provider, this key is stored in different locations:
@@ -416,7 +416,7 @@ system_key_directory: "/etc/scylla/system_encryption_keys"
 # Note that by default the {{ inventory_hostname }} is part of the localhost_table_key_directory. This allows you to define
 # different keys per host.
 # e.g.:
-# If your localhost_table_key_directory is set to "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/table_encryption_keys"
+# If your localhost_table_key_directory is set to "{{ playbook_dir }}/encryption_at_rest/{{ inventory_hostname }}/table_encryption_keys"
 # and you have the following file tree:
 #
 # ├── encryption_at_rest
@@ -436,7 +436,7 @@ system_key_directory: "/etc/scylla/system_encryption_keys"
 # without the {{ inventory_hostname }} in it or simply copy the same key for all the node folders.
 
 handle_table_keys: false
-localhost_table_key_directory: "{{ inventory_dir }}/encryption_at_rest/{{ inventory_hostname }}/table_encryption_keys"
+localhost_table_key_directory: "{{ playbook_dir }}/encryption_at_rest/{{ inventory_hostname }}/table_encryption_keys"
 table_key_directory: "/etc/scylla/table_encryption_keys"
 
 # Encrypt system resources:

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -93,7 +93,9 @@ install_only: false
 # Change here or override in vars
 scylla_nic: "{{ ansible_default_ipv4.interface }}"
 
-manager_local_files_path: "{{ playbook_dir }}"
+# Deprecated: override manager_local_files_path instead
+cluster_local_files_path: "{{ playbook_dir }}"
+manager_local_files_path: "{{ cluster_local_files_path }}"
 
 # online|offline - offline will disable all the attepts to download packages
 # node_exporter will need to be installed manually

--- a/ansible-scylla-node/tasks/adjust_keyspace_replication.yml
+++ b/ansible-scylla-node/tasks/adjust_keyspace_replication.yml
@@ -29,6 +29,7 @@
       vars:
         iv_file: "{{ item }}"
       loop: "{{ ansible_inventory_sources }}"
+  run_once: true
   when: scylla_admin_default_user is defined and 'cql_credentials' in groups
 
 - fail:

--- a/ansible-scylla-node/tasks/adjust_keyspace_replication.yml
+++ b/ansible-scylla-node/tasks/adjust_keyspace_replication.yml
@@ -1,32 +1,34 @@
 ---
-- name: Validate that all nodes are up before adjusting the replication
-  uri:
-    url: "http://{{ scylla_api_address }}:{{ scylla_api_port }}/failure_detector/endpoints/"
-    follow_redirects: none
-    method: GET
-  register: _result
-  until: _result.status == 200
-  retries: 10
-  delay: 1
-
 - name: Get datacenter name
   uri:
-    url: "http://{{ scylla_api_address }}:{{ scylla_api_port }}/snitch/datacenter"
+    url: "http://{{ hostvars[item]['scylla_api_address'] | default(hostvars[item]['broadcast_address']) }}:{{ hostvars[item]['scylla_api_port'] | default(scylla_api_port) }}/snitch/datacenter"
     method: GET
   register: _datacenter_out
   until: _datacenter_out.status == 200
   retries: 5
   delay: 1
-
-- name: Prepare per DC replication_factor list
-  set_fact:
-    dcs_to_rf: "{{ dcs_to_rf | default([]) + [\"'\" + hostvars[item]['_datacenter_out'].json + \"':\" + _keyspace_rf|string] }}"
+  delegate_to: "{{ item }}"
   loop: "{{ groups['scylla'] }}"
   run_once: true
 
-- set_fact:
-    scylla_admin_username: "{{ scylla_admin_default_user }}"
-    scylla_admin_password: "{{ lookup('ini', scylla_admin_default_user, section='cql_credentials', allow_no_value=true, default=omit, file=inventory_file) }}"
+- name: Prepare per DC replication_factor list
+  set_fact:
+    dcs_to_rf: "{{ dcs_to_rf | default([]) + [\"'\" + item.json + \"':\" + _keyspace_rf|string] }}"
+  loop: "{{ _datacenter_out.results }}"
+  run_once: true
+  when: item.json is defined
+
+- name: Set scylla_admin_username and scylla_admin_password
+  block:
+    - name: Set scylla_admin_username
+      set_fact:
+        scylla_admin_username: "{{ scylla_admin_default_user }}"
+
+    - name: Look for cql_credentials in the inventories and read scylla_admin_password
+      include_tasks: read_admin_password.yml
+      vars:
+        iv_file: "{{ item }}"
+      loop: "{{ ansible_inventory_sources }}"
   when: scylla_admin_default_user is defined and 'cql_credentials' in groups
 
 - fail:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -360,7 +360,13 @@
             exit 1
           fi
 
-          count=$(nodetool status | grep -E '^UN|^UJ|^DN' | grep -Ew "{{ broadcast_address_list | join('|') }}" | wc -l)
+          status=$(nodetool status)
+          count=0
+          {% for addr in broadcast_address_list %}
+          if echo "$status" | grep -E '^UN|^UJ|^DN' | grep -Fq '{{ addr }}'; then
+            count=$((count + 1))
+          fi
+          {% endfor %}
           if [[ "$count" == "{{ play_hosts|length }}" ]]; then
             exit 0
           fi
@@ -418,6 +424,7 @@
       shell: |
         nodetool status|grep -E '^UJ|^DN' | wc -l
       register: node_count
+      become: true
 
     - name: Set all_nodes_up as a fact
       set_fact:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -344,13 +344,28 @@
         timeout: 300
 
     - name: wait for the cluster to become healthy
-      shell: |
-        nodetool status|grep -E '^UN|^UJ|^DN'|wc -l
+      shell:
+        executable: /bin/bash
+        cmd: |
+          state=$(systemctl is-active scylla-server)
+
+          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+            echo "scylla-server has unexpectedly stopped"
+            exit 1
+          fi
+
+          count=$(nodetool status | grep -E '^UN|^UJ|^DN' | wc -l)
+          if [[ "$count" == "{{ ansible_play_batch|length }}" ]]; then
+            exit 0
+          fi
+
+          exit 2
       register: node_count
-      until: node_count.stdout|int == ansible_play_batch|length
+      until: node_count.rc != 2
       retries: "{{ scylla_bootstrap_wait_time_sec|int }}"
       delay: 1
       when: full_inventory|bool
+      become: true
 
     - name: check API access
       uri:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -78,7 +78,7 @@
 - name: Create a map from dc to its list of nodes
   set_fact:
     dc_to_node_list: "{{ dc_to_node_list | default({}) | combine( {hostvars[item]['dc']: (dc_to_node_list | default({}))[hostvars[item]['dc']] | default([]) + [item]} ) }}"
-  loop: "{{ groups['scylla'] }}"
+  loop: "{{ play_hosts }}"
   run_once: true
   when: scylla_io_probe_dc_aware|bool
 
@@ -324,7 +324,7 @@
       include_tasks: start_one_node.yml
       vars:
         node: "{{ item }}"
-      loop: "{{ groups['scylla'] }}"
+      loop: "{{ play_hosts }}"
       when: hostvars[item]['broadcast_address'] in scylla_seeds or item in scylla_seeds
 
     - name: Start scylla non-seeds nodes serially
@@ -332,7 +332,7 @@
       include_tasks: start_one_node.yml
       vars:
         node: "{{ item }}"
-      loop: "{{ groups['scylla'] }}"
+      loop: "{{ play_hosts }}"
       when:
         - item not in scylla_seeds
         - hostvars[item]['broadcast_address'] not in scylla_seeds
@@ -342,6 +342,12 @@
         port: "{{ scylla_api_port }}"
         host: "{{ scylla_api_address }}"
         timeout: 300
+
+    - name: Create a list with the broadcast addresses of the nodes in play_hosts
+      set_fact:
+        broadcast_address_list: "{{ broadcast_address_list | default([]) + [hostvars[item]['broadcast_address']] }}"
+      loop: "{{ play_hosts }}"
+      run_once: true
 
     - name: wait for the cluster to become healthy
       shell:
@@ -354,8 +360,8 @@
             exit 1
           fi
 
-          count=$(nodetool status | grep -E '^UN|^UJ|^DN' | wc -l)
-          if [[ "$count" == "{{ ansible_play_batch|length }}" ]]; then
+          count=$(nodetool status | grep -E '^UN|^UJ|^DN' | grep -Ew "{{ broadcast_address_list | join('|') }}" | wc -l)
+          if [[ "$count" == "{{ play_hosts|length }}" ]]; then
             exit 0
           fi
 
@@ -406,6 +412,18 @@
           {% if (_scylla_yaml_map.audit is defined and _scylla_yaml_map.audit == 'table') %}True{% else %}False{% endif %}
   run_once: true
 
+- name: Check if all nodes are up
+  block:
+    - name: Check if there are joining or down nodes
+      shell: |
+        nodetool status|grep -E '^UJ|^DN' | wc -l
+      register: node_count
+
+    - name: Set all_nodes_up as a fact
+      set_fact:
+        all_nodes_up: "{{ node_count.stdout|int == 0 }}"
+  run_once: true
+
 - name: Adjust replication for system_auth keyspace
   include_tasks: adjust_keyspace_replication.yml
   vars:
@@ -413,7 +431,7 @@
     _keyspace_replication_strategy: "{{ system_auth_replication_strategy }}"
     _keyspace_rf: "{{ system_auth_rf }}"
   when:
-    - start_scylla_service|bool
+    - all_nodes_up|bool
     - adjust_system_auth_replication is defined and adjust_system_auth_replication|bool
     - _authentication_enabled is defined and _authentication_enabled|bool
     - system_auth_rf is defined and system_auth_replication_strategy is defined
@@ -425,7 +443,7 @@
     _keyspace_replication_strategy: "{{ audit_replication_strategy }}"
     _keyspace_rf: "{{ audit_rf }}"
   when:
-    - start_scylla_service|bool
+    - all_nodes_up|bool
     - adjust_audit_replication is defined and adjust_audit_replication|bool
     - _audit_enabled is defined and _audit_enabled|bool
     - audit_rf is defined and audit_replication_strategy is defined
@@ -437,7 +455,7 @@
     _keyspace_replication_strategy: "{{ system_distributed_replication_strategy }}"
     _keyspace_rf: "{{ system_distributed_rf }}"
   when:
-    - start_scylla_service|bool
+    - all_nodes_up|bool
     - adjust_system_distributed_replication is defined and adjust_system_distributed_replication|bool
     - system_distributed_rf is defined and system_distributed_replication_strategy is defined
 
@@ -448,7 +466,7 @@
     _keyspace_replication_strategy: "{{ system_traces_replication_strategy }}"
     _keyspace_rf: "{{ system_traces_rf }}"
   when:
-    - start_scylla_service|bool
+    - all_nodes_up|bool
     - adjust_system_traces_replication is defined and adjust_system_traces_replication|bool
     - system_traces_rf is defined and system_traces_replication_strategy is defined
 

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -349,8 +349,8 @@
         cmd: |
           state=$(systemctl is-active scylla-server)
 
-          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-            echo "scylla-server has unexpectedly stopped"
+          if [[ "$state" != "active" && "$state" != "activating" ]]; then
+            echo "scylla-server is not running (state: $state)"
             exit 1
           fi
 

--- a/ansible-scylla-node/tasks/generate_tokens.yml
+++ b/ansible-scylla-node/tasks/generate_tokens.yml
@@ -7,13 +7,19 @@
       register: _scylla_yaml_stat
       delegate_to: "{{ item }}"
       delegate_facts: true
+      ignore_errors: true
+      ignore_unreachable: true
       when: item not in play_hosts
       loop: "{{ groups['scylla'] }}"
 
     - name: Set _scylla_yaml_exists as a fact
       set_fact:
         _scylla_yaml_exists: "{{ item.stat.exists }}"
-      when: item.item not in play_hosts
+      when:
+        - item.item is defined
+        - item.item not in play_hosts
+        - not item.unreachable | default(false)
+        - item.stat is defined
       delegate_to: "{{ item.item }}"
       delegate_facts: true
       loop: "{{ _scylla_yaml_stat.results }}"
@@ -23,7 +29,10 @@
       command: cat /etc/scylla/scylla.yaml
       register: _scylla_yaml_out
       delegate_to: "{{ item }}"
-      when: item not in play_hosts and hostvars[item]['_scylla_yaml_exists']|bool
+      ignore_errors: true
+      ignore_unreachable: true
+      changed_when: false
+      when: item not in play_hosts and hostvars[item]['_scylla_yaml_exists'] | default(false) | bool
       loop: "{{ groups['scylla'] }}"
 
     - name: Set _scylla_yaml_map as a fact
@@ -31,7 +40,9 @@
         _scylla_yaml_map: "{{ item.stdout | from_yaml }}"
       delegate_to: "{{ item.item }}"
       delegate_facts: true
-      when: item.stdout is defined
+      when:
+        - item.stdout is defined
+        - not item.unreachable | default(false)
       loop: "{{ _scylla_yaml_out.results }}"
 
     - name: Set addresses as facts
@@ -40,7 +51,10 @@
         broadcast_address: "{{ hostvars[item]['_scylla_yaml_map'].broadcast_address }}"
       delegate_to: "{{ item }}"
       delegate_facts: true
-      when: item not in play_hosts and hostvars[item]['_scylla_yaml_exists']|bool
+      when:
+        - item not in play_hosts
+        - hostvars[item]['_scylla_yaml_exists'] | default(false) | bool
+        - hostvars[item]['_scylla_yaml_map'] is defined
       loop: "{{ groups['scylla'] }}"
 
 - name: Find the first node which is already bootstrapped, if any

--- a/ansible-scylla-node/tasks/generate_tokens.yml
+++ b/ansible-scylla-node/tasks/generate_tokens.yml
@@ -1,4 +1,48 @@
 ---
+- name: Get relevant addresses for nodes that are not in play_hosts
+  block:
+    - name: check if scylla.yaml exists
+      stat:
+        path: /etc/scylla/scylla.yaml
+      register: _scylla_yaml_stat
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      when: item not in play_hosts
+      loop: "{{ groups['scylla'] }}"
+
+    - name: Set _scylla_yaml_exists as a fact
+      set_fact:
+        _scylla_yaml_exists: "{{ item.stat.exists }}"
+      when: item.item not in play_hosts
+      delegate_to: "{{ item.item }}"
+      delegate_facts: true
+      loop: "{{ _scylla_yaml_stat.results }}"
+
+    # Let's assume that a node can only be started if it has a scylla yaml
+    - name: Register scylla.yaml
+      command: cat /etc/scylla/scylla.yaml
+      register: _scylla_yaml_out
+      delegate_to: "{{ item }}"
+      when: item not in play_hosts and hostvars[item]['_scylla_yaml_exists']|bool
+      loop: "{{ groups['scylla'] }}"
+
+    - name: Set _scylla_yaml_map as a fact
+      set_fact:
+        _scylla_yaml_map: "{{ item.stdout | from_yaml }}"
+      delegate_to: "{{ item.item }}"
+      delegate_facts: true
+      when: item.stdout is defined
+      loop: "{{ _scylla_yaml_out.results }}"
+
+    - name: Set addresses as facts
+      set_fact:
+        rpc_address: "{{ hostvars[item]['_scylla_yaml_map'].rpc_address }}"
+        broadcast_address: "{{ hostvars[item]['_scylla_yaml_map'].broadcast_address }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      when: item not in play_hosts and hostvars[item]['_scylla_yaml_exists']|bool
+      loop: "{{ groups['scylla'] }}"
+
 - name: Find the first node which is already bootstrapped, if any
   wait_for:
     port: 9042
@@ -7,7 +51,8 @@
   register: wait_for_cql_port_output
   ignore_errors: true
   delegate_to: "{{ item }}"
-  loop: "{{ groups['scylla'] }}"
+  loop: "{{ scylla_seeds }}"
+  when: wait_for_cql_port_output is not defined or wait_for_cql_port_output.failed == True
 
 - name: Set the already bootstrapped node as a fact, if any
   set_fact:
@@ -20,6 +65,7 @@
     node_list: "{{ node_list | default([]) + [hostvars[item]['broadcast_address']] }}"
     rack_list: "{{ rack_list | default([]) + [hostvars[item]['rack']] }}"
     dc_list: "{{ dc_list | default([]) + [hostvars[item]['dc'] + hostvars[item]['dc_suffix'] | default('')] }}"
+  when: hostvars[item]['broadcast_address'] is defined
   loop: "{{ groups['scylla'] }}"
 
 - name: Create a temporary tokens file
@@ -39,6 +85,7 @@
       retries: 5
       delay: 1
       delegate_to: "{{ bootstrapped_node }}"
+      when: hostvars[item]['broadcast_address'] is defined
       loop: "{{ groups['scylla'] }}"
 
     - name: Copy tokens to tmp file
@@ -46,7 +93,7 @@
         path: "{{ tokens_file.path }}"
         line: "{{ hostvars[item.item]['broadcast_address'] }}={{ item.json | map('int') | join(',') }}"
         create: yes
-      when: item.json|length > 0
+      when: hostvars[item.item]['broadcast_address'] is defined and item.json|length > 0
       delegate_to: localhost
       loop: "{{ _existing_tokens.results }}"
   when: bootstrapped_node is defined
@@ -76,4 +123,4 @@
   when: item[0].split('=')[0] == hostvars[item[1]]['broadcast_address']
   with_nested:
     - "{{ _new_tokens.stdout_lines }}"
-    - "{{ groups['scylla'] }}"
+    - "{{ play_hosts }}"

--- a/ansible-scylla-node/tasks/manager_agents.yml
+++ b/ansible-scylla-node/tasks/manager_agents.yml
@@ -2,7 +2,7 @@
 
 - name: check for pre-existing agent-token file
   stat:
-    path: "{{ cluster_local_files_path }}/scyllamgr_auth_token.txt"
+    path: "{{ manager_local_files_path }}/scyllamgr_auth_token.txt"
   register: token_file_stat
   run_once: true
   delegate_to: localhost
@@ -20,14 +20,14 @@
     copy:
       content: |
         {{ scyllamgr_auth_token.stdout }}
-      dest: "{{ cluster_local_files_path }}/scyllamgr_auth_token.txt"
+      dest: "{{ manager_local_files_path }}/scyllamgr_auth_token.txt"
     delegate_to: localhost
     run_once: true
   when: token_file_stat.stat.islnk is not defined
 
 - name: read the key from auth token file
   slurp:
-    src: "{{ cluster_local_files_path }}/scyllamgr_auth_token.txt"
+    src: "{{ manager_local_files_path }}/scyllamgr_auth_token.txt"
   register: b64auth_token
   delegate_to: localhost
   run_once: true

--- a/ansible-scylla-node/tasks/read_admin_password.yml
+++ b/ansible-scylla-node/tasks/read_admin_password.yml
@@ -1,0 +1,6 @@
+---
+- name: Set password for scylla_admin
+  set_fact:
+    scylla_admin_password: "{{ lookup('ini', scylla_admin_username, section='cql_credentials', allow_no_value=true, default=omit, file=iv_file) }}"
+    inventory_with_credentials: "{{ iv_file }}"
+  ignore_errors: true

--- a/ansible-scylla-node/tasks/read_admin_password.yml
+++ b/ansible-scylla-node/tasks/read_admin_password.yml
@@ -1,6 +1,10 @@
 ---
-- name: Set password for scylla_admin
+- name: Look up scylla_admin password in inventory file
   set_fact:
-    scylla_admin_password: "{{ lookup('ini', scylla_admin_username, section='cql_credentials', allow_no_value=true, default=omit, file=iv_file) }}"
+    _scylla_admin_password_candidate: "{{ lookup('ini', scylla_admin_username | default(scylla_admin_default_user, true), section='cql_credentials', allow_no_value=true, default='', file=iv_file) }}"
+
+- name: Set scylla_admin_password from inventory file
+  set_fact:
+    scylla_admin_password: "{{ _scylla_admin_password_candidate }}"
     inventory_with_credentials: "{{ iv_file }}"
-  ignore_errors: true
+  when: _scylla_admin_password_candidate | length > 0

--- a/ansible-scylla-node/tasks/ssl.yml
+++ b/ansible-scylla-node/tasks/ssl.yml
@@ -137,6 +137,6 @@
 - name: Generate cqlshrc
   template:
     src: templates/cqlshrc.j2
-    dest: "{{ inventory_dir }}/cqlshrc"
+    dest: "{{ playbook_dir }}/cqlshrc"
   delegate_to: localhost
   run_once: true

--- a/ansible-scylla-node/tasks/start_one_node.yml
+++ b/ansible-scylla-node/tasks/start_one_node.yml
@@ -13,8 +13,8 @@
     cmd: |
       state=$(systemctl is-active scylla-server)
 
-      if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-        echo "scylla-server has unexpectedly stopped"
+      if [[ "$state" != "active" && "$state" != "activating" ]]; then
+        echo "scylla-server is not running (state: $state)"
         exit 1
       fi
 

--- a/example-playbooks/manage_users/manage_users.yml
+++ b/example-playbooks/manage_users/manage_users.yml
@@ -63,9 +63,13 @@
       when: _authentication_enabled|bool == false
       run_once: true
 
-    - name: Set password for scylla_admin
-      set_fact:
-        scylla_admin_password: "{{ lookup('ini', scylla_admin_username, section='cql_credentials', allow_no_value=true, default=omit, file=inventory_file) }}"
+    - name: Loop through inventories to find scylla_admin credentials
+      block:
+        - name: Try to read scylla_admin credentials in the current inventory
+          include_tasks: ../../ansible-scylla-node/tasks/read_admin_password.yml
+          vars:
+            iv_file: "{{ item }}"
+          loop: "{{ ansible_inventory_sources }}"
 
     - name: Create scylla_admin user
       import_tasks: create_user.yml
@@ -85,7 +89,7 @@
         admin_username: "{{ scylla_admin_username }}"
         admin_password: "{{ scylla_admin_password }}"
         username: "{{ item.key }}"
-        password: "{{ lookup('ini', item.key, section='cql_credentials', allow_no_value=true, default=omit, file=inventory_file) }}"
+        password: "{{ lookup('ini', item.key, section='cql_credentials', allow_no_value=true, default=omit, file=inventory_with_credentials) }}"
         permissions: "{{ item.value.permissions }}"
       loop: "{{ internal_users | dict2items }}"
       run_once: true

--- a/example-playbooks/manage_users/manage_users.yml
+++ b/example-playbooks/manage_users/manage_users.yml
@@ -70,6 +70,12 @@
           vars:
             iv_file: "{{ item }}"
           loop: "{{ ansible_inventory_sources }}"
+      run_once: true
+
+    - fail:
+        msg: "scylla_admin password not found in any inventory file ([cql_credentials] section)"
+      when: scylla_admin_password is not defined
+      run_once: true
 
     - name: Create scylla_admin user
       import_tasks: create_user.yml

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -355,8 +355,8 @@
         cmd: |
           state=$(systemctl is-active scylla-server)
 
-          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-            echo "scylla-server has unexpectedly stopped"
+          if [[ "$state" != "active" && "$state" != "activating" ]]; then
+            echo "scylla-server is not running (state: $state)"
             exit 1
           fi
 

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -350,12 +350,29 @@
     - vars/main.yml
   tasks:
     - name: Wait for the added node to become healthy
-      shell: |
-        nodetool status|grep -E '^UN'|grep -w "{{ hostvars[new_node]['broadcast_address'] }}"| wc -l
+      shell:
+        executable: /bin/bash
+        cmd: |
+          state=$(systemctl is-active scylla-server)
+
+          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+            echo "scylla-server has unexpectedly stopped"
+            exit 1
+          fi
+
+          count=$(nodetool status | grep -E '^UN' | grep -w "{{ hostvars[new_node]['broadcast_address'] }}" | wc -l)
+          if [[ "$count" == "1" ]]; then
+            exit 0
+          fi
+
+          exit 2
       register: node_count
-      until: node_count.stdout|int == 1
+      delegate_to: "{{ new_node }}"
+      run_once: true
+      until: node_count.rc != 2
       retries: "{{ scylla_bootstrap_wait_time_sec|int }}"
       delay: 1
+      become: true
 
     - name: start and enable the Manager agent service
       service:

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -87,7 +87,7 @@ provisioner:
       scylla-manager:
         scylla_clusters:
           - cluster_name: "test-cluster"
-            auth_token_file: "{{ inventory_dir }}/scyllamgr_auth_token.txt"
+            auth_token_file: "{{ playbook_dir }}/scyllamgr_auth_token.txt"
             host: "10.11.0.2"
             without_repair: false
         scylla_debian_dependencies:

--- a/molecule/debian12/molecule.yml
+++ b/molecule/debian12/molecule.yml
@@ -86,7 +86,7 @@ provisioner:
       scylla-manager:
         scylla_clusters:
           - cluster_name: "test-cluster"
-            auth_token_file: "{{ inventory_dir }}/scyllamgr_auth_token.txt"
+            auth_token_file: "{{ playbook_dir }}/scyllamgr_auth_token.txt"
             host: "10.11.0.2"
             without_repair: false
         scylla_debian_dependencies:

--- a/molecule/rockylinux10/molecule.yml
+++ b/molecule/rockylinux10/molecule.yml
@@ -88,7 +88,7 @@ provisioner:
       scylla-manager:
         scylla_clusters:
           - cluster_name: "test-cluster"
-            auth_token_file: "{{ inventory_dir }}/scyllamgr_auth_token.txt"
+            auth_token_file: "{{ playbook_dir }}/scyllamgr_auth_token.txt"
             host: "10.11.0.2"
             without_repair: false
       scylla-monitor:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -88,7 +88,7 @@ provisioner:
       scylla-manager:
         scylla_clusters:
           - cluster_name: "test-cluster"
-            auth_token_file: "{{ inventory_dir }}/scyllamgr_auth_token.txt"
+            auth_token_file: "{{ playbook_dir }}/scyllamgr_auth_token.txt"
             host: "10.11.0.2"
             without_repair: false
       scylla-monitor:

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -86,7 +86,7 @@ provisioner:
       scylla-manager:
         scylla_clusters:
           - cluster_name: "test-cluster"
-            auth_token_file: "{{ inventory_dir }}/scyllamgr_auth_token.txt"
+            auth_token_file: "{{ playbook_dir }}/scyllamgr_auth_token.txt"
             host: "10.11.0.2"
             without_repair: false
       scylla-monitor:

--- a/molecule/ubuntu2404/molecule.yml
+++ b/molecule/ubuntu2404/molecule.yml
@@ -86,7 +86,7 @@ provisioner:
       scylla-manager:
         scylla_clusters:
           - cluster_name: "test-cluster"
-            auth_token_file: "{{ inventory_dir }}/scyllamgr_auth_token.txt"
+            auth_token_file: "{{ playbook_dir }}/scyllamgr_auth_token.txt"
             host: "10.11.0.2"
             without_repair: false
         scylla_debian_dependencies:


### PR DESCRIPTION
## Summary
- Reimplements #366 against current `dev`: `play_hosts` for bootstrap/token loops, `playbook_dir` for local artifacts (manager token, SSL, encryption keys), `ansible_inventory_sources` for multi-inventory `cql_credentials` lookup
- Bootstrap health wait filters nodetool by `play_hosts` broadcast addresses (works with `--limit`); replication adjustment gated on cluster-wide `all_nodes_up` via nodetool
- Molecule `auth_token_file` paths updated to `playbook_dir` to match converge playbook location

## Test plan
- [ ] Run molecule scenario (e.g. `ubuntu2204`) end-to-end
- [ ] Bootstrap full cluster without `--limit`
- [ ] Bootstrap with `--limit` on subset of nodes (`full_inventory: true`)
- [ ] Multi-inventory run: `-i hosts.ini -i secrets.ini` with `[cql_credentials]` in secrets file
- [ ] Verify manager agent token written under playbook dir and consumed by manager role


Made with [Cursor](https://cursor.com)