### PR TITLE
ansible-scylla-manager: Update default SM version from 3.5 to 3.11

### DIFF
--- a/ansible-scylla-manager/defaults/main.yml
+++ b/ansible-scylla-manager/defaults/main.yml
@@ -2,8 +2,8 @@
 # defaults file for ansible-scylla-manager
 
 # Repo URL for the Manager
-scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.5.list"
-scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.5.repo"
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.11.list"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.11.repo"
 
 # The manager installs a local ScyllaDB, which is used only by the Manager.
 # Repo URLs for the ScyllaDB datastore installation

--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -476,8 +476,8 @@ system_info_encryption_kms:
 # If Scylla Manager will be used, set the following variables
 scylla_manager_enabled: true
 
-scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.5.list"
-scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.5.repo"
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.11.list"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.11.repo"
 
 scylla_manager_agent_upgrade: true
 


### PR DESCRIPTION
The default Scylla Manager repo URLs pointed to version 3.5, which is incompatible with the latest ScyllaDB version used by default. Update to Manager 3.11 to ensure compatibility.