### PR TITLE
scylla-manager: automatically set Alternator credentials

### DIFF
--- a/ansible-scylla-manager/tasks/add_cluster.yml
+++ b/ansible-scylla-manager/tasks/add_cluster.yml
@@ -8,6 +8,16 @@
     echo $(sctool status|grep -q "Cluster: {{ item.cluster_name }} " && echo "present")
   register: cluster_already_added
 
+- name: Fetch alternator salted hash for "{{ item.username }}"
+  shell: |
+    cqlsh {{ item.host }} -u '{{ item.username }}' -p '{{ item.password }}' \
+      -e "SELECT salted_hash FROM system.roles WHERE role = '{{ item.username }}';" \
+      | grep -E '^\s+\$' | tr -d ' '
+  register: alternator_salted_hash
+  when:
+    - item.username is defined
+    - item.password is defined
+
 - name: run sctool cluster add for "{{ item.cluster_name }}"
   shell: |
     sctool cluster add \
@@ -19,6 +29,12 @@
       {% if item.username is defined and item.password is defined %}
       --username {{ item.username }} \
       --password {{ item.password }} \
+      {% endif %}
+      {% if alternator_salted_hash is defined
+         and alternator_salted_hash.stdout is defined
+         and alternator_salted_hash.stdout != '' %}
+      --alternator-access-key-id {{ item.username }} \
+      --alternator-secret-access-key '{{ alternator_salted_hash.stdout }}' \
       {% endif %}
   when: cluster_already_added is not defined or cluster_already_added.stdout != "present"
 
@@ -32,6 +48,12 @@
       {% if item.username is defined and item.password is defined %}
       --username {{ item.username }} \
       --password {{ item.password }} \
+      {% endif %}
+      {% if alternator_salted_hash is defined
+         and alternator_salted_hash.stdout is defined
+         and alternator_salted_hash.stdout != '' %}
+      --alternator-access-key-id {{ item.username }} \
+      --alternator-secret-access-key '{{ alternator_salted_hash.stdout }}' \
       {% endif %}
   when: cluster_already_added is defined and cluster_already_added.stdout == "present"
       

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -344,13 +344,28 @@
         timeout: 300
 
     - name: wait for the cluster to become healthy
-      shell: |
-        nodetool status|grep -E '^UN|^UJ|^DN'|wc -l
+      shell:
+        executable: /bin/bash
+        cmd: |
+          state=$(systemctl is-active scylla-server)
+
+          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+            echo "scylla-server has unexpectedly stopped"
+            exit 1
+          fi
+
+          count=$(nodetool status | grep -E '^UN|^UJ|^DN' | wc -l)
+          if [[ "$count" == "{{ ansible_play_batch|length }}" ]]; then
+            exit 0
+          fi
+
+          exit 2
       register: node_count
-      until: node_count.stdout|int == ansible_play_batch|length
+      until: node_count.rc != 2
       retries: "{{ scylla_bootstrap_wait_time_sec|int }}"
       delay: 1
       when: full_inventory|bool
+      become: true
 
     - name: check API access
       uri:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -349,8 +349,8 @@
         cmd: |
           state=$(systemctl is-active scylla-server)
 
-          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-            echo "scylla-server has unexpectedly stopped"
+          if [[ "$state" != "active" && "$state" != "activating" ]]; then
+            echo "scylla-server is not running (state: $state)"
             exit 1
           fi
 

--- a/ansible-scylla-node/tasks/start_one_node.yml
+++ b/ansible-scylla-node/tasks/start_one_node.yml
@@ -13,8 +13,8 @@
     cmd: |
       state=$(systemctl is-active scylla-server)
 
-      if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-        echo "scylla-server has unexpectedly stopped"
+      if [[ "$state" != "active" && "$state" != "activating" ]]; then
+        echo "scylla-server is not running (state: $state)"
         exit 1
       fi
 

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -355,8 +355,8 @@
         cmd: |
           state=$(systemctl is-active scylla-server)
 
-          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
-            echo "scylla-server has unexpectedly stopped"
+          if [[ "$state" != "active" && "$state" != "activating" ]]; then
+            echo "scylla-server is not running (state: $state)"
             exit 1
           fi
 

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -350,12 +350,29 @@
     - vars/main.yml
   tasks:
     - name: Wait for the added node to become healthy
-      shell: |
-        nodetool status|grep -E '^UN'|grep -w "{{ hostvars[new_node]['broadcast_address'] }}"| wc -l
+      shell:
+        executable: /bin/bash
+        cmd: |
+          state=$(systemctl is-active scylla-server)
+
+          if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+            echo "scylla-server has unexpectedly stopped"
+            exit 1
+          fi
+
+          count=$(nodetool status | grep -E '^UN' | grep -w "{{ hostvars[new_node]['broadcast_address'] }}" | wc -l)
+          if [[ "$count" == "1" ]]; then
+            exit 0
+          fi
+
+          exit 2
       register: node_count
-      until: node_count.stdout|int == 1
+      delegate_to: "{{ new_node }}"
+      run_once: true
+      until: node_count.rc != 2
       retries: "{{ scylla_bootstrap_wait_time_sec|int }}"
       delay: 1
+      become: true
 
     - name: start and enable the Manager agent service
       service:


### PR DESCRIPTION
Replaces #525 (opened from a fork the automation can no longer read). Same change, branch now pushed directly to this repo.

Newer Scylla Managers, in combination with Alternator-enabled clusters, will attempt to retrieve the Alternator schema using Alternator credentials when performing a backup. In order to be able to perform a backup, we must set these credentials.

Also fixes the alternator-hash lookup to run on the manager node itself (no `delegate_to`), so it only needs network access to the cluster's CQL port instead of SSH/Ansible connectivity to the scylla node being queried.

Made with [Cursor](https://cursor.com)