### PR TITLE
Persist scylla-monitoring start/stop wrapper scripts on deploy

### DIFF
--- a/ansible-scylla-monitoring/defaults/main.yml
+++ b/ansible-scylla-monitoring/defaults/main.yml
@@ -26,6 +26,7 @@ scylla_monitoring_role_config_path: "{{ inventory_dir }}"
 scylla_monitoring_deploy_path: /opt/scylla-monitoring
 scylla_monitoring_start_script_path: "{{ scylla_monitoring_deploy_path }}/start-monitoring.sh"
 scylla_monitoring_stop_script_path: "{{ scylla_monitoring_deploy_path }}/stop-monitoring.sh"
+scylla_monitoring_start_env_path: "{{ scylla_monitoring_deploy_path }}/start-monitoring.env"
 scylla_monitoring_data_path: "{{ scylla_monitoring_deploy_path }}/data"
 scylla_monitoring_config_path:  "{{ scylla_monitoring_deploy_path }}/config"
 scylla_monitoring_prom_rules_path:  "{{ scylla_monitoring_config_path }}/prom_rules"

--- a/ansible-scylla-monitoring/defaults/main.yml
+++ b/ansible-scylla-monitoring/defaults/main.yml
@@ -24,6 +24,8 @@ scylla_monitoring_archive_url: 'https://github.com/scylladb/scylla-monitoring/ar
 scylla_monitoring_role_config_path: "{{ inventory_dir }}"
 
 scylla_monitoring_deploy_path: /opt/scylla-monitoring
+scylla_monitoring_start_script_path: "{{ scylla_monitoring_deploy_path }}/start-monitoring.sh"
+scylla_monitoring_stop_script_path: "{{ scylla_monitoring_deploy_path }}/stop-monitoring.sh"
 scylla_monitoring_data_path: "{{ scylla_monitoring_deploy_path }}/data"
 scylla_monitoring_config_path:  "{{ scylla_monitoring_deploy_path }}/config"
 scylla_monitoring_prom_rules_path:  "{{ scylla_monitoring_config_path }}/prom_rules"

--- a/ansible-scylla-monitoring/tasks/docker.yml
+++ b/ansible-scylla-monitoring/tasks/docker.yml
@@ -31,6 +31,20 @@
   when: "'cql_credentials' in groups and item.split('=')[0] == scylla_monitoring_cql_default_user | default('scylla_cql_monitor')"
   loop: "{{ groups['cql_credentials'] }}"
 
+- name: "docker.yml: Write stop monitoring wrapper script"
+  template:
+    src: stop-monitoring.sh.j2
+    dest: "{{ scylla_monitoring_stop_script_path }}"
+    mode: '0750'
+    owner: "{{ ansible_user_id }}"
+
+- name: "docker.yml: Write start monitoring wrapper script"
+  template:
+    src: start-monitoring.sh.j2
+    dest: "{{ scylla_monitoring_start_script_path }}"
+    mode: '0750'
+    owner: "{{ ansible_user_id }}"
+
 - name: "docker.yml: restart the docker daemon again"
   service:
     name: docker
@@ -49,16 +63,8 @@
   when: ansible_facts.services["docker.service"] is defined
 
 - name: "docker.yml: Stop monitoring"
-  shell: |
-    cd {{ base_dir }}
-    ./kill-all.sh
-    sudo ./kill-all.sh
+  command: "{{ scylla_monitoring_stop_script_path }}"
 
 - name: "docker.yml: start scylla-monitoring"
-  shell: "{{ start_command }}"
-  args:
-    chdir: "{{ base_dir }}"
+  command: "{{ scylla_monitoring_start_script_path }}"
   become: "{{ 'true' if run_docker_with_sudo is defined and run_docker_with_sudo|bool == True else 'false' }}"
-  environment:
-    SCYLLA_USER: "{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}{{ monitoring_cql_username }}{% endif %}"
-    SCYLLA_PSSWD: "{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}{{ monitoring_cql_password }}{% endif %}"

--- a/ansible-scylla-monitoring/tasks/docker.yml
+++ b/ansible-scylla-monitoring/tasks/docker.yml
@@ -38,6 +38,14 @@
     mode: '0750'
     owner: "{{ ansible_user_id }}"
 
+- name: "docker.yml: Write start monitoring env file"
+  template:
+    src: start-monitoring.env.j2
+    dest: "{{ scylla_monitoring_start_env_path }}"
+    mode: '0600'
+    owner: "{{ ansible_user_id }}"
+  when: monitoring_cql_username is defined and monitoring_cql_password is defined
+
 - name: "docker.yml: Write start monitoring wrapper script"
   template:
     src: start-monitoring.sh.j2
@@ -68,3 +76,6 @@
 - name: "docker.yml: start scylla-monitoring"
   command: "{{ scylla_monitoring_start_script_path }}"
   become: "{{ 'true' if run_docker_with_sudo is defined and run_docker_with_sudo|bool == True else 'false' }}"
+  environment:
+    SCYLLA_USER: "{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}{{ monitoring_cql_username }}{% endif %}"
+    SCYLLA_PSSWD: "{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}{{ monitoring_cql_password }}{% endif %}"

--- a/ansible-scylla-monitoring/templates/start-monitoring.env.j2
+++ b/ansible-scylla-monitoring/templates/start-monitoring.env.j2
@@ -1,0 +1,4 @@
+{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}
+export SCYLLA_USER={{ monitoring_cql_username | quote }}
+export SCYLLA_PSSWD={{ monitoring_cql_password | quote }}
+{% endif %}

--- a/ansible-scylla-monitoring/templates/start-monitoring.sh.j2
+++ b/ansible-scylla-monitoring/templates/start-monitoring.sh.j2
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd {{ base_dir }}
+{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}
+export SCYLLA_USER='{{ monitoring_cql_username }}'
+export SCYLLA_PSSWD='{{ monitoring_cql_password }}'
+{% endif %}
+{{ start_command }}

--- a/ansible-scylla-monitoring/templates/start-monitoring.sh.j2
+++ b/ansible-scylla-monitoring/templates/start-monitoring.sh.j2
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd {{ base_dir }}
-{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}
-export SCYLLA_USER='{{ monitoring_cql_username }}'
-export SCYLLA_PSSWD='{{ monitoring_cql_password }}'
-{% endif %}
+cd {{ base_dir | quote }}
+ENV_FILE={{ scylla_monitoring_start_env_path | quote }}
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+fi
 {{ start_command }}

--- a/ansible-scylla-monitoring/templates/stop-monitoring.sh.j2
+++ b/ansible-scylla-monitoring/templates/stop-monitoring.sh.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd {{ base_dir }}
+./kill-all.sh || true
+sudo ./kill-all.sh || true

--- a/ansible-scylla-monitoring/templates/stop-monitoring.sh.j2
+++ b/ansible-scylla-monitoring/templates/stop-monitoring.sh.j2
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd {{ base_dir }}
-./kill-all.sh || true
-sudo ./kill-all.sh || true
+cd {{ base_dir | quote }}
+./kill-all.sh || sudo ./kill-all.sh || true


### PR DESCRIPTION
## Summary
- Write `/opt/scylla-monitoring/start-monitoring.sh` and `/opt/scylla-monitoring/stop-monitoring.sh` during `ansible-scylla-monitoring` deploy
- Use the wrapper scripts for role stop/start instead of inline shell commands
- Enables easy manual or fcsh-driven monitoring restarts without reconstructing `start-all.sh` args

Related: scylladb/field-engineering#2607

## Test plan
- [ ] Run monitoring role against a test monitor host
- [ ] Verify scripts exist at `/opt/scylla-monitoring/{start,stop}-monitoring.sh` with mode 0750
- [ ] `./stop-monitoring.sh` stops containers; `./start-monitoring.sh` brings stack back up
- [ ] Re-run `Update_monitoring` Jenkins job on a Field Cloud cluster


Made with [Cursor](https://cursor.com)