### PR TITLE
scylla-manager: automatically set Alternator credentials (#528)

### DIFF
--- a/ansible-scylla-manager/tasks/add_cluster.yml
+++ b/ansible-scylla-manager/tasks/add_cluster.yml
@@ -8,6 +8,16 @@
     echo $(sctool status|grep -q "Cluster: {{ item.cluster_name }} " && echo "present")
   register: cluster_already_added
 
+- name: Fetch alternator salted hash for "{{ item.username }}"
+  shell: |
+    cqlsh {{ item.host }} -u '{{ item.username }}' -p '{{ item.password }}' \
+      -e "SELECT salted_hash FROM system.roles WHERE role = '{{ item.username }}';" \
+      | grep -E '^\s+\$' | tr -d ' '
+  register: alternator_salted_hash
+  when:
+    - item.username is defined
+    - item.password is defined
+
 - name: run sctool cluster add for "{{ item.cluster_name }}"
   shell: |
     sctool cluster add \
@@ -19,6 +29,12 @@
       {% if item.username is defined and item.password is defined %}
       --username {{ item.username }} \
       --password {{ item.password }} \
+      {% endif %}
+      {% if alternator_salted_hash is defined
+         and alternator_salted_hash.stdout is defined
+         and alternator_salted_hash.stdout != '' %}
+      --alternator-access-key-id {{ item.username }} \
+      --alternator-secret-access-key '{{ alternator_salted_hash.stdout }}' \
       {% endif %}
   when: cluster_already_added is not defined or cluster_already_added.stdout != "present"
 
@@ -32,6 +48,12 @@
       {% if item.username is defined and item.password is defined %}
       --username {{ item.username }} \
       --password {{ item.password }} \
+      {% endif %}
+      {% if alternator_salted_hash is defined
+         and alternator_salted_hash.stdout is defined
+         and alternator_salted_hash.stdout != '' %}
+      --alternator-access-key-id {{ item.username }} \
+      --alternator-secret-access-key '{{ alternator_salted_hash.stdout }}' \
       {% endif %}
   when: cluster_already_added is defined and cluster_already_added.stdout == "present"
       

--- a/ansible-scylla-manager/tasks/add_cluster.yml
+++ b/ansible-scylla-manager/tasks/add_cluster.yml
@@ -11,9 +11,15 @@
 - name: Fetch alternator salted hash for "{{ item.username }}"
   shell: |
     cqlsh {{ item.host }} -u '{{ item.username }}' -p '{{ item.password }}' \
+      {% if item.ssl is defined and item.ssl|bool %}--ssl{% endif %} \
       -e "SELECT salted_hash FROM system.roles WHERE role = '{{ item.username }}';" \
       | grep -E '^\s+\$' | tr -d ' '
   register: alternator_salted_hash
+  # Alternator creds are best-effort: TLS-only clusters, transient network/auth
+  # failures, or missing SELECT on system.roles must not abort the cluster add/update.
+  failed_when: false
+  # stdout is a credential-equivalent secret; keep it out of Ansible logs/-vvv output.
+  no_log: true
   when:
     - item.username is defined
     - item.password is defined
@@ -36,6 +42,8 @@
       --alternator-access-key-id {{ item.username }} \
       --alternator-secret-access-key '{{ alternator_salted_hash.stdout }}' \
       {% endif %}
+  # Command line embeds username/password and the alternator secret; suppress logging.
+  no_log: true
   when: cluster_already_added is not defined or cluster_already_added.stdout != "present"
 
 - name: Enforce configuration for existing cluster "{{ item.cluster_name }}"
@@ -55,5 +63,7 @@
       --alternator-access-key-id {{ item.username }} \
       --alternator-secret-access-key '{{ alternator_salted_hash.stdout }}' \
       {% endif %}
+  # Command line embeds username/password and the alternator secret; suppress logging.
+  no_log: true
   when: cluster_already_added is defined and cluster_already_added.stdout == "present"
       


### PR DESCRIPTION
Cherry-pick https://github.com/scylladb/scylla-ansible-roles/pull/528 to master.