### PR TITLE
fix(replace): own service startup suppression

### DIFF
--- a/ansible-scylla-node/defaults/main.yml
+++ b/ansible-scylla-node/defaults/main.yml
@@ -167,6 +167,10 @@ cleanup_timeout_seconds: 36000
 # this should be set to false
 start_scylla_service: true
 
+# Let operation playbooks suppress automatic service startup even when reused
+# deployment parameters set start_scylla_service to true.
+skip_start_scylla_service: false
+
 # Only relevant for Debian/Ubuntu
 scylla_repo_keyserver: 'hkp://keyserver.ubuntu.com:80'
 scylla_repo_keys:

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -426,7 +426,7 @@
     _keyspace_replication_strategy: "{{ system_auth_replication_strategy }}"
     _keyspace_rf: "{{ system_auth_rf }}"
   when:
-    - start_scylla_service|bool
+    - start_scylla_service is defined and start_scylla_service|bool
     - not skip_start_scylla_service|bool
     - adjust_system_auth_replication is defined and adjust_system_auth_replication|bool
     - _authentication_enabled is defined and _authentication_enabled|bool
@@ -439,7 +439,7 @@
     _keyspace_replication_strategy: "{{ audit_replication_strategy }}"
     _keyspace_rf: "{{ audit_rf }}"
   when:
-    - start_scylla_service|bool
+    - start_scylla_service is defined and start_scylla_service|bool
     - not skip_start_scylla_service|bool
     - adjust_audit_replication is defined and adjust_audit_replication|bool
     - _audit_enabled is defined and _audit_enabled|bool
@@ -452,7 +452,7 @@
     _keyspace_replication_strategy: "{{ system_distributed_replication_strategy }}"
     _keyspace_rf: "{{ system_distributed_rf }}"
   when:
-    - start_scylla_service|bool
+    - start_scylla_service is defined and start_scylla_service|bool
     - not skip_start_scylla_service|bool
     - adjust_system_distributed_replication is defined and adjust_system_distributed_replication|bool
     - system_distributed_rf is defined and system_distributed_replication_strategy is defined
@@ -464,7 +464,7 @@
     _keyspace_replication_strategy: "{{ system_traces_replication_strategy }}"
     _keyspace_rf: "{{ system_traces_rf }}"
   when:
-    - start_scylla_service|bool
+    - start_scylla_service is defined and start_scylla_service|bool
     - not skip_start_scylla_service|bool
     - adjust_system_traces_replication is defined and adjust_system_traces_replication|bool
     - system_traces_rf is defined and system_traces_replication_strategy is defined

--- a/ansible-scylla-node/tasks/common.yml
+++ b/ansible-scylla-node/tasks/common.yml
@@ -395,7 +395,9 @@
         line: ""
       become: true
       when: token_distributor is defined
-  when: start_scylla_service is defined and start_scylla_service|bool
+  when:
+    - start_scylla_service is defined and start_scylla_service|bool
+    - not skip_start_scylla_service|bool
 
 - name: Copy system and table keys
   include_tasks: copy_system_and_table_keys.yml
@@ -425,6 +427,7 @@
     _keyspace_rf: "{{ system_auth_rf }}"
   when:
     - start_scylla_service|bool
+    - not skip_start_scylla_service|bool
     - adjust_system_auth_replication is defined and adjust_system_auth_replication|bool
     - _authentication_enabled is defined and _authentication_enabled|bool
     - system_auth_rf is defined and system_auth_replication_strategy is defined
@@ -437,6 +440,7 @@
     _keyspace_rf: "{{ audit_rf }}"
   when:
     - start_scylla_service|bool
+    - not skip_start_scylla_service|bool
     - adjust_audit_replication is defined and adjust_audit_replication|bool
     - _audit_enabled is defined and _audit_enabled|bool
     - audit_rf is defined and audit_replication_strategy is defined
@@ -449,6 +453,7 @@
     _keyspace_rf: "{{ system_distributed_rf }}"
   when:
     - start_scylla_service|bool
+    - not skip_start_scylla_service|bool
     - adjust_system_distributed_replication is defined and adjust_system_distributed_replication|bool
     - system_distributed_rf is defined and system_distributed_replication_strategy is defined
 
@@ -460,6 +465,7 @@
     _keyspace_rf: "{{ system_traces_rf }}"
   when:
     - start_scylla_service|bool
+    - not skip_start_scylla_service|bool
     - adjust_system_traces_replication is defined and adjust_system_traces_replication|bool
     - system_traces_rf is defined and system_traces_replication_strategy is defined
 

--- a/ansible-scylla-node/tasks/manager_agents.yml
+++ b/ansible-scylla-node/tasks/manager_agents.yml
@@ -60,4 +60,7 @@
     state: restarted
     enabled: yes
   become: true
-  when: manager_agent_config_change.changed and start_scylla_service is defined and start_scylla_service|bool
+  when:
+    - manager_agent_config_change.changed
+    - start_scylla_service is defined and start_scylla_service|bool
+    - not skip_start_scylla_service|bool

--- a/example-playbooks/replace_node/README.md
+++ b/example-playbooks/replace_node/README.md
@@ -7,7 +7,6 @@ This playbook will run the replace dead node procedure.
 * A scylla cluster with scylla-manager and scylla-monitoring installed.
 * The inventory file must be updated as described in the Usage section below, ie.: The new node should replace the dead node in the inventory.
 * It's necessary to have files with the same parameters used when the cluster was created, as described in the Parameters section.
-* It's very important to have `start_scylla_service` set to `false`. The replace will not work otherwise.
 
 ## Usage:
 
@@ -50,6 +49,8 @@ This playbook uses the node role to install and configure Scylla in the new node
 and use Scylla Manager to issue a repair if needed.
 So the same parameters for all three roles (node, monitoring and manager) that were
 used when the cluster was created should also be passed to the `replace_node.yml` playbook.
+The playbook suppresses automatic Scylla startup while applying the node role, regardless of the
+`start_scylla_service` value in those reused parameters.
 See the `Usage` section of this README for the way how these parameters are supposed to be passed.
 
 Besides the vars from the node role, this playbook has the following mandatory parameters: `replaced_node`, `replaced_node_broadcast_address` and `new_node`.

--- a/example-playbooks/replace_node/replace_node.yml
+++ b/example-playbooks/replace_node/replace_node.yml
@@ -151,7 +151,9 @@
   vars:
     disable_firewall: false
   roles:
-    - ansible-scylla-node
+    - role: ansible-scylla-node
+      vars:
+        skip_start_scylla_service: true
 
 
 - name: Update scylla-monitoring

--- a/example-playbooks/replace_node/vars/main.yml
+++ b/example-playbooks/replace_node/vars/main.yml
@@ -9,12 +9,6 @@
 # scylla_seeds:
 #   - "{{ groups['scylla'][0] }}"
 
-# This should always be set to False, since it'll be passed to the node role
-# and we don't want the node role to start the new node automatically.
-# If you're reusing (as expected) the parameters you used to deploy the other nodes,
-# make sure that you set this specific value to false
-start_scylla_service: false
-
 # By default, the playbook will repair the new node only if RBNO was not used
 # during the replacement.
 # If you set this to true, the repair will be skipped even in such case.


### PR DESCRIPTION
## Summary
- add a role-level `skip_start_scylla_service` safety gate
- make `replace_node.yml` set the gate while installing/configuring the replacement node
- remove the requirement for reused deployment params to set `start_scylla_service: false`

## Context
Reimplements scylladb/field-engineering#2940 after scylladb/field-engineering#3218 was reverted.

The earlier change relied on `example-playbooks/replace_node/vars/main.yml`, but automation passes `nodes_params.yml` with `-e @file`. Those extra vars have higher precedence and commonly set `start_scylla_service: true`, causing Scylla to start before replacement metadata is configured.

This change gives the replace playbook an independent role control. It suppresses automatic Scylla startup, related replication adjustment, and Manager agent startup even when reused deployment parameters enable normal service startup. The playbook still starts the replacement explicitly after setting `replace_node_first_boot` or `replace_address_first_boot`.

## Test plan
- [x] Parse all modified YAML files with PyYAML
- [x] Run `ansible-playbook --syntax-check` with repository async plugins and required `new_node` variable

Made with [Cursor](https://cursor.com)