### PR TITLE
ci: fix molecule DinD volume leak and broaden test-roles triggers (ANSROLES-20)

### DIFF
--- a/.github/workflows/test-roles.yml
+++ b/.github/workflows/test-roles.yml
@@ -46,3 +46,8 @@ jobs:
       - name: Test with molecule
         run: |
           molecule destroy --scenario-name ${{ matrix.molecule_distro }} && molecule test --scenario-name ${{ matrix.molecule_distro }}
+      # ANSROLES-20: molecule destroy drops scylla-monitor-node but keeps its named
+      # DinD volume (molecule-dind-<distro>). Remove explicitly so runner disk does not fill.
+      - name: Remove molecule DinD volume
+        if: always()
+        run: docker volume rm -f "molecule-dind-${{ matrix.molecule_distro }}" || true

--- a/.github/workflows/test-roles.yml
+++ b/.github/workflows/test-roles.yml
@@ -6,14 +6,18 @@ on:
       - 'ansible-scylla-node/**'
       - 'ansible-scylla-monitoring/**'
       - 'ansible-scylla-manager/**'
-      - '.github/workflows/*'
+      - 'molecule/**'
+      - '.github/workflows/test-roles.yml'
   pull_request:
     paths:
       - 'ansible-scylla-node/**'
       - 'ansible-scylla-monitoring/**'
       - 'ansible-scylla-manager/**'
+      - 'molecule/**'
+      - '.github/workflows/test-roles.yml'
     branches:
       - master
+      - dev
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/test-roles.yml
+++ b/.github/workflows/test-roles.yml
@@ -51,7 +51,10 @@ jobs:
         run: |
           molecule destroy --scenario-name ${{ matrix.molecule_distro }} && molecule test --scenario-name ${{ matrix.molecule_distro }}
       # ANSROLES-20: molecule destroy drops scylla-monitor-node but keeps its named
-      # DinD volume (molecule-dind-<distro>). Remove explicitly so runner disk does not fill.
+      # DinD volume (molecule-dind-<distro>-<run_id>). Remove explicitly so runner disk
+      # does not fill. Warn (do not swallow) if removal fails for a real reason.
       - name: Remove molecule DinD volume
         if: always()
-        run: docker volume rm -f "molecule-dind-${{ matrix.molecule_distro }}" || true
+        run: |
+          volume="molecule-dind-${{ matrix.molecule_distro }}-${{ github.run_id }}"
+          docker volume rm -f "$volume" || echo "::warning::failed to remove volume $volume"

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -56,7 +56,10 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - /sys/kernel/security:/sys/kernel/security:ro # Prevent container from modifying host AppArmor profile
-      - /var/lib/docker # https://github.com/docker/for-linux/issues/1138
+      # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
+      # the container rootfs). See https://github.com/docker/for-linux/issues/1138
+      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
+      - molecule-dind-debian11:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -58,8 +58,9 @@ platforms:
       - /sys/kernel/security:/sys/kernel/security:ro # Prevent container from modifying host AppArmor profile
       # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
       # the container rootfs). See https://github.com/docker/for-linux/issues/1138
-      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
-      - molecule-dind-debian11:/var/lib/docker
+      # Named + per-run (run_id) so CI can docker volume rm after destroy while staying
+      # unique across concurrent same-distro runs; defaults to "local" outside CI — ANSROLES-20.
+      - molecule-dind-debian11-${GITHUB_RUN_ID:-local}:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/debian12/molecule.yml
+++ b/molecule/debian12/molecule.yml
@@ -57,8 +57,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup
       # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
       # the container rootfs). See https://github.com/docker/for-linux/issues/1138
-      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
-      - molecule-dind-debian12:/var/lib/docker
+      # Named + per-run (run_id) so CI can docker volume rm after destroy while staying
+      # unique across concurrent same-distro runs; defaults to "local" outside CI — ANSROLES-20.
+      - molecule-dind-debian12-${GITHUB_RUN_ID:-local}:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/debian12/molecule.yml
+++ b/molecule/debian12/molecule.yml
@@ -55,7 +55,10 @@ platforms:
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
-      - /var/lib/docker # https://github.com/docker/for-linux/issues/1138
+      # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
+      # the container rootfs). See https://github.com/docker/for-linux/issues/1138
+      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
+      - molecule-dind-debian12:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/rockylinux10/molecule.yml
+++ b/molecule/rockylinux10/molecule.yml
@@ -59,8 +59,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
       # the container rootfs). See https://github.com/docker/for-linux/issues/1138
-      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
-      - molecule-dind-rockylinux10:/var/lib/docker
+      # Named + per-run (run_id) so CI can docker volume rm after destroy while staying
+      # unique across concurrent same-distro runs; defaults to "local" outside CI — ANSROLES-20.
+      - molecule-dind-rockylinux10-${GITHUB_RUN_ID:-local}:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/rockylinux10/molecule.yml
+++ b/molecule/rockylinux10/molecule.yml
@@ -57,7 +57,10 @@ platforms:
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - /var/lib/docker # https://github.com/docker/for-linux/issues/1138
+      # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
+      # the container rootfs). See https://github.com/docker/for-linux/issues/1138
+      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
+      - molecule-dind-rockylinux10:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -57,7 +57,10 @@ platforms:
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - /var/lib/docker # https://github.com/docker/for-linux/issues/1138
+      # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
+      # the container rootfs). See https://github.com/docker/for-linux/issues/1138
+      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
+      - molecule-dind-rockylinux9:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -59,8 +59,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
       # the container rootfs). See https://github.com/docker/for-linux/issues/1138
-      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
-      - molecule-dind-rockylinux9:/var/lib/docker
+      # Named + per-run (run_id) so CI can docker volume rm after destroy while staying
+      # unique across concurrent same-distro runs; defaults to "local" outside CI — ANSROLES-20.
+      - molecule-dind-rockylinux9-${GITHUB_RUN_ID:-local}:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -55,7 +55,10 @@ platforms:
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
-      - /var/lib/docker # https://github.com/docker/for-linux/issues/1138
+      # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
+      # the container rootfs). See https://github.com/docker/for-linux/issues/1138
+      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
+      - molecule-dind-ubuntu2204:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -57,8 +57,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup
       # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
       # the container rootfs). See https://github.com/docker/for-linux/issues/1138
-      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
-      - molecule-dind-ubuntu2204:/var/lib/docker
+      # Named + per-run (run_id) so CI can docker volume rm after destroy while staying
+      # unique across concurrent same-distro runs; defaults to "local" outside CI — ANSROLES-20.
+      - molecule-dind-ubuntu2204-${GITHUB_RUN_ID:-local}:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/ubuntu2404/molecule.yml
+++ b/molecule/ubuntu2404/molecule.yml
@@ -57,8 +57,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup
       # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
       # the container rootfs). See https://github.com/docker/for-linux/issues/1138
-      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
-      - molecule-dind-ubuntu2404:/var/lib/docker
+      # Named + per-run (run_id) so CI can docker volume rm after destroy while staying
+      # unique across concurrent same-distro runs; defaults to "local" outside CI — ANSROLES-20.
+      - molecule-dind-ubuntu2404-${GITHUB_RUN_ID:-local}:/var/lib/docker
     groups:
       - scylla-monitor
     networks:

--- a/molecule/ubuntu2404/molecule.yml
+++ b/molecule/ubuntu2404/molecule.yml
@@ -55,7 +55,10 @@ platforms:
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
-      - /var/lib/docker # https://github.com/docker/for-linux/issues/1138
+      # DinD: nested dockerd needs /var/lib/docker on a volume (overlay cannot sit on
+      # the container rootfs). See https://github.com/docker/for-linux/issues/1138
+      # Named (not anonymous) so CI can docker volume rm after destroy — ANSROLES-20.
+      - molecule-dind-ubuntu2404:/var/lib/docker
     groups:
       - scylla-monitor
     networks:


### PR DESCRIPTION
## Summary
- **ANSROLES-20:** Use per-scenario named DinD volumes (`molecule-dind-<distro>:/var/lib/docker`) on `scylla-monitor-node` and remove them in an `if: always()` step after molecule, so orphan volumes stop filling the self-hosted runner disk.
- **Triggers (separate commit):** Run molecule when `molecule/**` or `test-roles.yml` change; allow `pull_request` targeting `dev`; keep the workflow path filter scoped to this file (not all of `.github/workflows/`).

## Commits
1. `ci: clean up molecule DinD volumes after tests (ANSROLES-20)`
2. `ci: run molecule on harness changes and PRs to dev`

## Test plan
- [ ] Molecule jobs run on this PR (base `dev` + path filters)
- [ ] After each matrix job, runner has no leftover `molecule-dind-<distro>` volume
- [ ] Monitoring DinD still works (volume still present for overlay; only name/cleanup changed)
- [ ] Editing an unrelated workflow does **not** start this matrix