### PR TITLE
ansible-scylla-monitoring: Grafana HTTPS user setup and readiness (ANSROLES-21, ANSROLES-22)

### DIFF
--- a/ansible-scylla-monitoring/tasks/docker.yml
+++ b/ansible-scylla-monitoring/tasks/docker.yml
@@ -79,3 +79,15 @@
   environment:
     SCYLLA_USER: "{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}{{ monitoring_cql_username }}{% endif %}"
     SCYLLA_PSSWD: "{% if monitoring_cql_username is defined and monitoring_cql_password is defined %}{{ monitoring_cql_password }}{% endif %}"
+
+# start-all.sh returns before Grafana is ready to serve API requests.
+# Wait here so subsequent tasks (e.g. grafana_users) do not hit a dead endpoint.
+- name: "docker.yml: Wait for Grafana API"
+  uri:
+    url: "{{ grafana_root_url }}/api/health"
+    validate_certs: false
+    status_code: 200
+  register: _grafana_health
+  until: _grafana_health.status == 200
+  retries: 30
+  delay: 10

--- a/ansible-scylla-monitoring/tasks/grafana_users.yml
+++ b/ansible-scylla-monitoring/tasks/grafana_users.yml
@@ -12,6 +12,7 @@
       url: "{{ grafana_root_url }}"
       url_username: "admin"
       url_password: "{{ grafana_admin_password }}"
+      validate_certs: false
       name: "{{ grafana_admin_user }}"
       email: "{{ grafana_admin_user }}@localhost"
       login: "{{ grafana_admin_user }}"
@@ -21,9 +22,10 @@
 
   - name: "grafana_users.yml: Drop default admin"
     community.grafana.grafana_user:
-      url: "http://localhost:3000"
+      url: "{{ grafana_root_url }}"
       url_username: "{{ grafana_admin_user }}"
       url_password: "{{ grafana_admin_password }}"
+      validate_certs: false
       login: "admin"
       state: absent
 


### PR DESCRIPTION
## Summary
- **ANSROLES-22**: Fix admin Grafana user tasks to use `grafana_root_url` and `validate_certs: false`, matching the viewer tasks and HTTPS/self-signed setups.
- **ANSROLES-21**: After starting monitoring containers, wait for Grafana `/api/health` so user-management tasks do not race a not-yet-ready API (avoids the masked `community.grafana` `NoneType.read` failure).

Fixes [ANSROLES-21](https://scylladb.atlassian.net/browse/ANSROLES-21)
Fixes [ANSROLES-22](https://scylladb.atlassian.net/browse/ANSROLES-22)

## Test plan
- [ ] Deploy monitoring with `grafana_enable_https: true` and default `grafana_admin_user: admin`
- [ ] Confirm wait task succeeds against `https://localhost:3000/api/health`
- [ ] Confirm viewer user create/recreate succeeds after start
- [ ] Deploy with non-default `grafana_admin_user` and confirm create + drop-default-admin work over HTTPS
- [ ] Deploy with HTTP (`grafana_enable_https: false`) and confirm wait + user tasks still pass

[ANSROLES-21]: https://scylladb.atlassian.net/browse/ANSROLES-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANSROLES-22]: https://scylladb.atlassian.net/browse/ANSROLES-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ