### PR TITLE
ci: scope molecule push trigger to master and dev

### DIFF
--- a/.github/workflows/test-roles.yml
+++ b/.github/workflows/test-roles.yml
@@ -2,6 +2,9 @@
 name: Molecule Test for ansible roles
 on:
   push:
+    branches:
+      - master
+      - dev
     paths:
       - 'ansible-scylla-node/**'
       - 'ansible-scylla-monitoring/**'


### PR DESCRIPTION
## Summary
- Scope the `push` trigger in `test-roles.yml` to `master`/`dev` instead of removing it.
- Same-repo PR branch updates no longer double-run the molecule matrix (`push` + `pull_request`).
- Merges into `master`/`dev` still get a post-merge molecule run via scoped `push`.

## Test plan
- [ ] Push a commit to this PR → exactly one Molecule workflow run (`pull_request`)
- [ ] No `push` event run for this feature branch
- [ ] After merge to `dev`, one Molecule run with event `push` on `dev`