### PR TITLE
ansible-scylla-common: remove stale iptables_drop_sources rules

### DIFF
--- a/ansible-scylla-common/README.md
+++ b/ansible-scylla-common/README.md
@@ -11,6 +11,8 @@ A common role providing shared tasks and utilities for all Scylla Ansible roles.
 
 - `disable_firewall`: Whether firewall should be disabled. (default: true, unless deprecated `firewall_enabled` is true)
 - `iptables_drop_sources`: List of source IPs to DROP on INPUT when `disable_firewall` is false. (default: `[]`)
+  Each run reconciles the INPUT chain to match this list exactly: sources present are
+  added, and any previously-applied DROP source no longer in the list is removed.
 
 ## Usage
 

--- a/ansible-scylla-common/defaults/main.yml
+++ b/ansible-scylla-common/defaults/main.yml
@@ -7,6 +7,9 @@ disable_firewall: "{{ not (firewall_enabled | default(false)) }}"
 
 # Source IPs that must have an INPUT DROP rule when disable_firewall is false.
 # Empty list means no DROP rules are managed by this role.
+# Entries must be bare IPv4 addresses (no /mask) — stale-rule reconciliation
+# compares against iptables' normalized "-S INPUT" output, which drops /32
+# and won't match a masked or subnet entry.
 iptables_drop_sources: []
 
 # A dictionary that defines which TCP addresses (IP or DNS) and ports must be reachable on the node(s) targeted by this role.

--- a/ansible-scylla-common/tasks/handle_firewall.yml
+++ b/ansible-scylla-common/tasks/handle_firewall.yml
@@ -33,3 +33,31 @@
   when:
     - not (disable_firewall | bool)
     - iptables_drop_sources | length > 0
+
+# Remove any previously-applied INPUT DROP rule whose source is no longer listed in
+# iptables_drop_sources, so a source dropped by a prior run (e.g. a replace-node
+# temporary block) doesn't linger once the role's default (empty list) applies again.
+- name: Find existing simple INPUT DROP rules
+  command: iptables -S INPUT
+  register: _current_input_rules
+  changed_when: false
+  become: true
+  when: not (disable_firewall | bool)
+
+- name: Remove stale INPUT DROP rules not in iptables_drop_sources
+  iptables:
+    chain: INPUT
+    source: "{{ item }}"
+    jump: DROP
+    state: absent
+  loop: "{{ _current_drop_sources | difference(iptables_drop_sources) }}"
+  become: true
+  vars:
+    _current_drop_sources: >-
+      {{
+        _current_input_rules.stdout_lines
+        | select('match', '^-A INPUT -s [0-9.]+(/[0-9]+)? -j DROP$')
+        | map('regex_replace', '^-A INPUT -s ([0-9.]+)(?:/[0-9]+)? -j DROP$', '\1')
+        | list
+      }}
+  when: not (disable_firewall | bool)

--- a/ansible-scylla-common/tasks/handle_firewall.yml
+++ b/ansible-scylla-common/tasks/handle_firewall.yml
@@ -41,6 +41,7 @@
   command: iptables -S INPUT
   register: _current_input_rules
   changed_when: false
+  check_mode: false
   become: true
   when: not (disable_firewall | bool)
 


### PR DESCRIPTION
## Summary
Follow-up to #531, per review feedback on scylladb/field-engineering#3209: when `disable_firewall` is `false`, the role only ever added INPUT DROP rules for sources in `iptables_drop_sources` — it never removed a DROP rule for a source that was in a *previous* run's list but isn't in the current one. That left temporary blocks (e.g. field-engineering's replace-node flow) stuck in place instead of being cleared on the next run with the default empty list.

- `ansible-scylla-common/tasks/handle_firewall.yml`: reads existing simple `-A INPUT -s <ip> -j DROP` rules via `iptables -S INPUT`, diffs them against `iptables_drop_sources`, and removes any rule whose source fell off the list.
- `ansible-scylla-common/README.md`: documents that each run reconciles the INPUT chain to match `iptables_drop_sources` exactly.

## Test plan
- [x] `ansible-playbook --syntax-check` against a playbook including this role
- [x] Verified the regex/`difference` reconciliation logic in isolation with a throwaway playbook (parses a mixed set of DROP/ACCEPT rules, confirms only the stale source is selected for removal)
- [ ] Molecule run (CI)