### PR TITLE
example-playbooks: Add upgrade_scylla_manager playbook

### DIFF
--- a/ansible-scylla-node/tasks/Debian.yml
+++ b/ansible-scylla-node/tasks/Debian.yml
@@ -143,6 +143,8 @@
 
   become: true
   when: scylla_manager_enabled|bool == true
+  tags:
+    - manager_agent_upgrade
 
 - name: install XFSprogs
   apt:

--- a/ansible-scylla-node/tasks/RedHat.yml
+++ b/ansible-scylla-node/tasks/RedHat.yml
@@ -148,3 +148,5 @@
 
   become: true
   when: scylla_manager_enabled|bool
+  tags:
+    - manager_agent_upgrade

--- a/ansible-scylla-node/tasks/main.yml
+++ b/ansible-scylla-node/tasks/main.yml
@@ -29,6 +29,8 @@
   - name: os-specific tasks
     include_tasks: "{{ ansible_os_family }}.yml"
     when: not upgrade_version
+    tags:
+      - manager_agent_upgrade
 
   - name: common tasks
     include_tasks: common.yml

--- a/example-playbooks/upgrade_scylla_manager/README.md
+++ b/example-playbooks/upgrade_scylla_manager/README.md
@@ -1,0 +1,38 @@
+# Upgrade Scylla Manager
+
+Upgrades the Scylla Manager server and `scylla-manager-agent` on all Scylla nodes.
+
+## Prerequisites
+
+* Inventory groups `scylla-manager` and `scylla`.
+* The same variables you used to deploy the cluster, in the same params files.
+
+## Update Params Files
+
+Point the Manager repo variables at the target series.
+
+In the manager params file (`group_vars/scylla-manager.yml`), for [ansible-scylla-manager](https://github.com/scylladb/scylla-ansible-roles/blob/master/ansible-scylla-manager/defaults/main.yml):
+
+```yaml
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.11.list"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.11.repo"
+```
+
+In the node params file (`group_vars/scylla.yml`), for the agents installed by [ansible-scylla-node](https://github.com/scylladb/scylla-ansible-roles/blob/master/ansible-scylla-node/defaults/main.yml):
+
+```yaml
+scylla_manager_deb_repo_url: "https://downloads.scylladb.com/deb/ubuntu/scylladb-manager-3.11.list"
+scylla_manager_rpm_repo_url: "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.11.repo"
+```
+
+## Trigger Upgrade
+
+```bash
+ANSIBLE_ROLES_PATH=$PATH_TO_YOUR_CLONED_REPO ansible-playbook -i inventory.ini $PATH_TO_YOUR_CLONED_REPO/example-playbooks/upgrade_scylla_manager/upgrade_scylla_manager.yml
+```
+
+This runs `ansible-scylla-node` in full. To only upgrade the manager agent and skip the rest of that role, add `--tags manager_agent_upgrade`; the other plays are tagged `always`, so they still run:
+
+```bash
+ANSIBLE_ROLES_PATH=$PATH_TO_YOUR_CLONED_REPO ansible-playbook -i inventory.ini --tags manager_agent_upgrade $PATH_TO_YOUR_CLONED_REPO/example-playbooks/upgrade_scylla_manager/upgrade_scylla_manager.yml
+```

--- a/example-playbooks/upgrade_scylla_manager/upgrade_scylla_manager.yml
+++ b/example-playbooks/upgrade_scylla_manager/upgrade_scylla_manager.yml
@@ -1,0 +1,131 @@
+---
+# Upgrade Scylla Manager server and scylla-manager-agent on all scylla nodes.
+#
+# Extra-vars scylla_manager_{deb,rpm}_repo_url should point at the target series.
+# Default (no --tags): full ansible-scylla-node. Optional: --tags manager_agent_upgrade
+# limits the node role to its manager-agent tasks; the other plays are tagged always,
+# so they keep running under any --tags selection.
+
+- name: Suspend Scylla Manager tasks
+  hosts: scylla-manager
+  gather_facts: no
+  tags:
+    - always
+  tasks:
+    - name: Require scylla_clusters with cluster_name on every entry
+      ansible.builtin.assert:
+        that:
+          - scylla_clusters is defined
+          - scylla_clusters | length > 0
+          - scylla_clusters | map(attribute='cluster_name') | select('defined') | list | length
+              == (scylla_clusters | length)
+        fail_msg: >-
+          scylla_clusters must be a non-empty list and every entry must have cluster_name for sctool.
+
+    - name: Manager unit state
+      ansible.builtin.command: systemctl is-active scylla-manager
+      register: manager_active
+      changed_when: false
+      failed_when: false
+
+    - name: Suspend tasks
+      ansible.builtin.shell: sctool --cluster="{{ item.cluster_name }}" suspend
+      loop: "{{ scylla_clusters }}"
+      loop_control:
+        label: "{{ item.cluster_name }}"
+      register: suspend_tasks
+      when: manager_active.stdout == "active"
+
+    - name: Suspend tasks operation output
+      ansible.builtin.debug:
+        var: suspend_tasks
+
+- name: Stop Scylla Manager server
+  hosts: scylla-manager
+  gather_facts: no
+  become: true
+  tags:
+    - always
+  tasks:
+    - name: Stop scylla-manager
+      ansible.builtin.systemd:
+        name: scylla-manager
+        state: stopped
+
+- name: Stop Scylla Manager agents
+  hosts: scylla
+  gather_facts: no
+  become: true
+  tags:
+    - always
+  tasks:
+    - name: Stop scylla-manager-agent
+      ansible.builtin.systemd:
+        name: scylla-manager-agent
+        state: stopped
+
+- name: Upgrade Scylla Manager via ansible-scylla-manager
+  hosts: scylla-manager
+  tags:
+    - always
+  vars:
+    enable_upgrade: true
+  roles:
+    - ansible-scylla-manager
+
+# No play-level tags here: they are inherited by every task of the role and would
+# defeat the manager_agent_upgrade tags inside it.
+- name: Upgrade manager agents via ansible-scylla-node
+  hosts: scylla
+  any_errors_fatal: true
+  vars:
+    scylla_manager_agent_upgrade: true
+    start_scylla_service: false
+  roles:
+    - ansible-scylla-node
+
+- name: Setup and start Scylla Manager agents
+  hosts: scylla
+  gather_facts: no
+  become: true
+  tags:
+    - always
+  tasks:
+    - name: scyllamgr_agent_setup -y
+      ansible.builtin.command: scyllamgr_agent_setup -y
+
+    - name: Start scylla-manager-agent
+      ansible.builtin.systemd:
+        name: scylla-manager-agent
+        state: started
+        enabled: true
+
+- name: Start Scylla Manager server
+  hosts: scylla-manager
+  gather_facts: no
+  become: true
+  tags:
+    - always
+  tasks:
+    - name: Start scylla-manager
+      ansible.builtin.systemd:
+        name: scylla-manager
+        state: started
+        enabled: true
+
+- name: Resume Scylla Manager tasks
+  hosts: scylla-manager
+  gather_facts: no
+  tags:
+    - always
+  tasks:
+    - name: Resume tasks
+      ansible.builtin.shell: sctool --cluster="{{ item.cluster_name }}" resume
+      loop: "{{ scylla_clusters }}"
+      loop_control:
+        label: "{{ item.cluster_name }}"
+      register: resume_tasks
+
+    - name: Resume tasks operation output
+      ansible.builtin.debug:
+        var: resume_tasks


### PR DESCRIPTION
This pull request introduces a new example playbook for upgrading Scylla Manager and its agents, and adds support for targeted upgrades of the manager agent in the `ansible-scylla-node` role. The changes improve the upgrade process by allowing operators to run only the relevant tasks for upgrading the Scylla Manager agent, and provide clear documentation and an example workflow for performing the upgrade.

**Upgrade workflow and documentation:**

* Added a new example playbook (`upgrade_scylla_manager.yml`) that automates the upgrade of Scylla Manager and `scylla-manager-agent` across all nodes, including suspending/resuming tasks, stopping/starting services, and running the appropriate roles.
* Added a comprehensive `README.md` explaining prerequisites, configuration, and step-by-step instructions for using the new upgrade playbook, including how to target only agent upgrades with Ansible tags.

**Ansible role improvements:**

* Added a `manager_agent_upgrade` tag to relevant tasks in `ansible-scylla-node` (`main.yml`, `Debian.yml`, `RedHat.yml`), enabling selective execution of only the manager agent upgrade tasks via `--tags manager_agent_upgrade`. [[1]](diffhunk://#diff-054bc36acbaac678d26c2717e183a5880da836eec9a2ab9e8a49da533f514ed8R32-R33) [[2]](diffhunk://#diff-e96c95b9a7e5fb494fbe3c9ecf35eb062ada676735c7cc3808a07434465d013bR146-R147) [[3]](diffhunk://#diff-d175c787cc6d3e1baf59b48b0bd02182a9f85a6da436133067aa1021e24cea61R151-R152)